### PR TITLE
Change NicknameClearCommand to use the name of target player for feedback

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/commands/NicknameClearCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/NicknameClearCommand.java
@@ -34,7 +34,7 @@ public class NicknameClearCommand implements Command<ServerCommandSource>  {
         //inform command sender that the nickname has been set
         context.getSource().sendFeedback(TextUtil.concat(
             ECText.getInstance().getText("cmd.nickname.set.feedback").setStyle(CONFIG.FORMATTING_DEFAULT.getValue()),
-            new LiteralText(senderPlayerEntity.getGameProfile().getName()),
+            new LiteralText(targetPlayer.getGameProfile().getName()),
             ECText.getInstance().getText("generic.quote_fullstop").setStyle(CONFIG.FORMATTING_DEFAULT.getValue())
         ), CONFIG.BROADCAST_TO_OPS.getValue());
 


### PR DESCRIPTION
I noticed when clearing a user's nickname that it showed the name of the sender when it appears based on https://github.com/John-Paul-R/Essential-Commands/blob/03c32d0ef7d3af086e5323b5b593489179045a6f/src/main/java/com/fibermc/essentialcommands/commands/NicknameClearCommand.java#L24-L29 it should be the target player when given a target. 