### PR TITLE
Adjust how fieldAsText method in Config handles optional values

### DIFF
--- a/ec-core/src/main/java/dev/jpcode/eccore/config/Config.java
+++ b/ec-core/src/main/java/dev/jpcode/eccore/config/Config.java
@@ -135,9 +135,10 @@ public abstract class Config {
     }
 
     private MutableText fieldAsText(Field field) throws IllegalAccessException {
+        var value = (Option)field.get(this);
         return new LiteralText("")
             .append(new LiteralText(field.getName() + ": ").setStyle(DEFAULT_STYLE))
-            .append(new LiteralText(field.get(this.getClass()).toString()));
+            .append(new LiteralText(value.getValue().toString()));
     }
 
     public @Nullable MutableText getFieldValueAsText(String fieldName) throws NoSuchFieldException {


### PR DESCRIPTION
When attempting to display the config currently you seen an exception related to the use of field.get() in this method. This change instead casts the field as an optional value and gets the string value of the optional. 

Due to https://github.com/John-Paul-R/Essential-Commands/blob/03c32d0ef7d3af086e5323b5b593489179045a6f/ec-core/src/main/java/dev/jpcode/eccore/config/Config.java#L63 only Optionals are supported in the config at this point. If that ever changes it may make sense to type check the fields like mentioned at https://stackoverflow.com/a/2262639