### PR TITLE
Remove PermissionCheckEvent handler registration, that allows all perms for OPs

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/ECPerms.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECPerms.java
@@ -77,14 +77,6 @@ public class ECPerms {
         worldDataManager.WARPS_LOAD_EVENT.register((warps) -> {
             Registry.per_warp_permissions = warps.keySet().toArray(new String[0]);
         });
-        if (CONFIG.USE_PERMISSIONS_API.getValue()) {
-            PermissionCheckEvent.EVENT.register((source, permission) -> {
-                if (isSuperAdmin(source)) {
-                    return TriState.TRUE;
-                }
-                return TriState.DEFAULT;
-            });
-        }
     }
 
     private static boolean isSuperAdmin(CommandSource source) {


### PR DESCRIPTION
This handler breaks permission checks in other mods, that using fabric-permission-api.
For example - https://github.com/Patbox/StyledChat/issues/18 https://github.com/samolego/CommandSpy/issues/4