### PR TITLE
Fix language not being initialized properly

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/ECText.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECText.java
@@ -28,7 +28,7 @@ public abstract class ECText {
     private static final Pattern TOKEN_PATTERN = Pattern.compile("%(\\d+\\$)?[\\d.]*[df]");
     public static final String DEFAULT_LANGUAGE = "en_us";
 
-    private static volatile ECText instance = create("en_us");
+    private static volatile ECText instance = create(CONFIG.LANGUAGE.getValue());
 
     private ECText() {}
 


### PR DESCRIPTION
Due to the initialization order, ECText's `instance` is initialized with the default language `en_us`, after `EssentialCommands.onInitialize` is called (that's when the configuration loads). Thus, `instance` will always be initialized with language `en_us` no matter what the configuration is.

It can be fixed by using `CONFIG.LANGUAGE` to create the instance. It should work on any initialization order.
