### PR TITLE
Add `afk` command

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/ECPerms.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECPerms.java
@@ -52,6 +52,7 @@ public class ECPerms {
         public static final String top = "essentialcommands.top";
         public static final String gametime = "essentialcommands.gametime";
         public static final String time_set_day = "essentialcommands.day";
+        public static final String afk = "essentialcommands.afk";
         public static final String config_reload = "essentialcommands.config.reload";
         public static final String bypass_teleport_delay = "essentialcommands.bypass.teleport_delay";
         public static final String bypass_allow_teleport_between_dimensions = "essentialcommands.bypass.allow_teleport_between_dimensions";

--- a/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
+++ b/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
@@ -386,6 +386,13 @@ public class EssentialCommandRegistry {
                 .build());
         }
 
+        if (CONFIG.ENABLE_AFK.getValue()) {
+            registerNode.accept(CommandManager.literal("afk")
+                .requires(ECPerms.require(ECPerms.Registry.afk, 0))
+                .executes(new AfkCommand())
+                .build());
+        }
+
         registerNode.accept(CommandManager.literal("lastPos")
             .requires(ECPerms.require("essentialcommands.admin.lastpos", 2))
                 .then(argument("target_player", StringArgumentType.word())

--- a/src/main/java/com/fibermc/essentialcommands/ManagerLocator.java
+++ b/src/main/java/com/fibermc/essentialcommands/ManagerLocator.java
@@ -49,7 +49,7 @@ public class ManagerLocator {
 
     public void onServerStart(MinecraftServer server) {
         this.playerDataManager = PlayerDataManager.getInstance();
-        this.tpManager = new TeleportRequestManager();
+        this.tpManager = TeleportRequestManager.getInstance();
         this.worldDataManager = WorldDataManager.createForServer(server);
         this.offlinePlayerRepo = new OfflinePlayerRepo(server);
     }

--- a/src/main/java/com/fibermc/essentialcommands/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/PlayerData.java
@@ -1,5 +1,6 @@
 package com.fibermc.essentialcommands;
 
+import com.fibermc.essentialcommands.events.PlayerActCallback;
 import com.fibermc.essentialcommands.types.MinecraftLocation;
 import com.fibermc.essentialcommands.types.NamedLocationStorage;
 import com.fibermc.essentialcommands.util.TimeUtil;
@@ -7,6 +8,8 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.jpcode.eccore.util.TextUtil;
 import io.github.ladysnake.pal.Pal;
 import io.github.ladysnake.pal.VanillaAbilities;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.player.PlayerAbilities;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
@@ -63,6 +66,7 @@ public class PlayerData extends PersistentState {
         tpTimer = -1;
         incomingTeleportRequests = new LinkedHashMap<>();
         homes = new NamedLocationStorage();
+        PLAYER_ACT_EVENT.register((packet) -> setAfk(false));
     }
 
     /**
@@ -168,6 +172,14 @@ public class PlayerData extends PersistentState {
     public MinecraftLocation getHomeLocation(String homeName) {
         return homes.get(homeName);
     }
+
+    public final Event<PlayerActCallback> PLAYER_ACT_EVENT = EventFactory.createArrayBacked(
+        PlayerActCallback.class,
+        (listeners) -> (packet) -> {
+            for (PlayerActCallback event : listeners) {
+                event.onPlayerAct(packet);
+            }
+        });
 
     public void setAfk(boolean afk) {
         if (this.afk == afk) {

--- a/src/main/java/com/fibermc/essentialcommands/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/PlayerData.java
@@ -170,12 +170,31 @@ public class PlayerData extends PersistentState {
     }
 
     public void setAfk(boolean afk) {
-        this.afk = afk;
+        if (this.afk == afk) {
+            return;
+        }
 
-        this.player.server.sendMessage(
-            ECText.getInstance().getText(
-                afk ? "player.afk.enter" : "player.afk.exit",
-                this.player.getDisplayName()));
+        if (afk) {
+            this.player.server.getPlayerManager().broadcast(
+                ECText.getInstance().getText(
+                    "player.afk.enter",
+                    this.player.getDisplayName()),
+                MessageType.SYSTEM);
+
+            // This assignment should happen after the message, otherwise
+            // `getDisplayName` will include the `[AFK]` prefix.
+            this.afk = afk;
+        } else {
+            // This assignment should happen before the message, otherwise
+            // `getDisplayName` will include the `[AFK]` prefix.
+            this.afk = afk;
+
+            this.player.server.getPlayerManager().broadcast(
+                ECText.getInstance().getText(
+                    "player.afk.exit",
+                    this.player.getDisplayName()),
+                MessageType.SYSTEM);
+        }
     }
 
     public boolean isAfk() {

--- a/src/main/java/com/fibermc/essentialcommands/TeleportRequestManager.java
+++ b/src/main/java/com/fibermc/essentialcommands/TeleportRequestManager.java
@@ -3,7 +3,6 @@ package com.fibermc.essentialcommands;
 import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
 import com.fibermc.essentialcommands.events.PlayerDamageCallback;
 import com.fibermc.essentialcommands.types.MinecraftLocation;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.network.message.MessageType;
 import net.minecraft.server.MinecraftServer;
@@ -27,7 +26,7 @@ public class TeleportRequestManager {
 
     private static TeleportRequestManager INSTANCE;
 
-    public TeleportRequestManager() {
+    private TeleportRequestManager() {
         INSTANCE = this;
         activeTpRequestList = new LinkedList<>();
         tpCooldownList = new LinkedList<>();
@@ -35,12 +34,16 @@ public class TeleportRequestManager {
     }
 
     public static TeleportRequestManager getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TeleportRequestManager();
+        }
         return INSTANCE;
     }
 
     public static void init() {
-        PlayerDamageCallback.EVENT.register((ServerPlayerEntity playerEntity, DamageSource source) -> TeleportRequestManager.INSTANCE.onPlayerDamaged(playerEntity, source));
-        ServerTickEvents.END_SERVER_TICK.register((MinecraftServer server) -> TeleportRequestManager.INSTANCE.tick(server));
+        getInstance();
+        PlayerDamageCallback.EVENT.register((ServerPlayerEntity playerEntity, DamageSource source) -> INSTANCE.onPlayerDamaged(playerEntity, source));
+        PlayerDataManager.TICK_EVENT.register(((playerDataManager, server) -> INSTANCE.tick(server)));
     }
 
     public void tick(MinecraftServer server) {

--- a/src/main/java/com/fibermc/essentialcommands/commands/AfkCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/AfkCommand.java
@@ -14,7 +14,7 @@ public class AfkCommand implements Command<ServerCommandSource> {
         var playerData = ((ServerPlayerEntityAccess) player).getEcPlayerData();
 
         // Message sending is done in here
-        playerData.setAfk(true);
+        playerData.setAfk(!playerData.isAfk());
 
         return 0;
     }

--- a/src/main/java/com/fibermc/essentialcommands/commands/AfkCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/AfkCommand.java
@@ -1,0 +1,21 @@
+package com.fibermc.essentialcommands.commands;
+
+import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.server.command.ServerCommandSource;
+
+public class AfkCommand implements Command<ServerCommandSource> {
+    @Override
+    public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        var source = context.getSource();
+        var player = source.getPlayer();
+        var playerData = ((ServerPlayerEntityAccess) player).getEcPlayerData();
+
+        // Message sending is done in here
+        playerData.setAfk(true);
+
+        return 0;
+    }
+}

--- a/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
+++ b/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
@@ -8,6 +8,7 @@ import dev.jpcode.eccore.config.Option;
 import dev.jpcode.eccore.util.TextUtil;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
@@ -40,6 +41,7 @@ public final class EssentialCommandsConfig extends Config {
     @ConfigOption public final Option<Boolean> ENABLE_TOP =             new Option<>("enable_top", true, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> ENABLE_GAMETIME =        new Option<>("enable_gametime", true, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> ENABLE_MOTD =            new Option<>("enable_motd", false, Boolean::parseBoolean);
+    @ConfigOption public final Option<Boolean> ENABLE_AFK =             new Option<>("enable_afk", true, Boolean::parseBoolean);
     @ConfigOption public final Option<List<Integer>> HOME_LIMIT =       new Option<>("home_limit", List.of(1, 2, 5), arrayParser(ConfigUtil::parseInt));
     @ConfigOption public final Option<Double>  TELEPORT_COOLDOWN =      new Option<>("teleport_cooldown", 1.0, ConfigUtil::parseDouble);
     @ConfigOption public final Option<Double>  TELEPORT_DELAY =         new Option<>("teleport_delay", 0.0, ConfigUtil::parseDouble);
@@ -61,6 +63,7 @@ public final class EssentialCommandsConfig extends Config {
     @ConfigOption public final Option<Boolean> GRANT_LOWEST_NUMERIC_BY_DEFAULT = new Option<>("grant_lowest_numeric_by_default", true, Boolean::parseBoolean);
     @ConfigOption public final Option<String> LANGUAGE = new Option<>("language", "en_us", String::toString);
     @ConfigOption public final Option<String> MOTD = new Option<>("motd", "<yellow>Welcome to our server <blue>%player:displayname%</blue>!\nPlease read the rules.</yellow>", String::toString);
+    @ConfigOption public final Option<Text> AFK_PREFIX = new Option<>("afk_prefix", Text.literal("[AFK] ").formatted(Formatting.GRAY), TextUtil::parseText, Text.Serializer::toJson);
 
     public EssentialCommandsConfig(Path savePath, String displayName, String documentationLink) {
         super(savePath, displayName, documentationLink);

--- a/src/main/java/com/fibermc/essentialcommands/events/PlayerActCallback.java
+++ b/src/main/java/com/fibermc/essentialcommands/events/PlayerActCallback.java
@@ -1,0 +1,8 @@
+package com.fibermc.essentialcommands.events;
+
+import net.minecraft.network.Packet;
+import net.minecraft.network.listener.ServerPlayPacketListener;
+
+public interface PlayerActCallback {
+    void onPlayerAct(Packet<ServerPlayPacketListener> packet);
+}

--- a/src/main/java/com/fibermc/essentialcommands/events/PlayerDataManagerTickCallback.java
+++ b/src/main/java/com/fibermc/essentialcommands/events/PlayerDataManagerTickCallback.java
@@ -1,0 +1,9 @@
+package com.fibermc.essentialcommands.events;
+
+import com.fibermc.essentialcommands.PlayerDataManager;
+import net.minecraft.server.MinecraftServer;
+
+public interface PlayerDataManagerTickCallback {
+
+    void onTick(PlayerDataManager playerDataManager, MinecraftServer server);
+}

--- a/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayNetworkHandlerMixin.java
@@ -4,10 +4,7 @@ import com.fibermc.essentialcommands.PlayerData;
 import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
 import net.minecraft.network.Packet;
 import net.minecraft.network.listener.ServerPlayPacketListener;
-import net.minecraft.network.packet.c2s.play.BoatPaddleStateC2SPacket;
-import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
-import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
-import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket;
+import net.minecraft.network.packet.c2s.play.*;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -18,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ServerPlayNetworkHandlerMixin {
 
     private PlayerData getPlayerData() {
-        var player= ((ServerPlayNetworkHandler)(Object)this).player;
+        var player = ((ServerPlayNetworkHandler) (Object) this).player;
         return ((ServerPlayerEntityAccess) player).getEcPlayerData();
     }
 
@@ -43,6 +40,11 @@ public class ServerPlayNetworkHandlerMixin {
 
     @Inject(method = "onBoatPaddleState", at = @At("RETURN"))
     public void onBoatPaddleState(BoatPaddleStateC2SPacket packet, CallbackInfo ci) {
+        invokeActEvent(packet);
+    }
+
+    @Inject(method = "onPlayerInteractEntity", at = @At("RETURN"))
+    public void onPlayerInteractEntity(PlayerInteractEntityC2SPacket packet, CallbackInfo ci) {
         invokeActEvent(packet);
     }
 }

--- a/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,48 @@
+package com.fibermc.essentialcommands.mixin;
+
+import com.fibermc.essentialcommands.PlayerData;
+import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
+import net.minecraft.network.Packet;
+import net.minecraft.network.listener.ServerPlayPacketListener;
+import net.minecraft.network.packet.c2s.play.BoatPaddleStateC2SPacket;
+import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
+import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
+import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public class ServerPlayNetworkHandlerMixin {
+
+    private PlayerData getPlayerData() {
+        var player= ((ServerPlayNetworkHandler)(Object)this).player;
+        return ((ServerPlayerEntityAccess) player).getEcPlayerData();
+    }
+
+    private void invokeActEvent(Packet<ServerPlayPacketListener> packet) {
+        getPlayerData().PLAYER_ACT_EVENT.invoker().onPlayerAct(packet);
+    }
+
+    @Inject(method = "onPlayerAction", at = @At("RETURN"))
+    public void onPlayerAction(PlayerActionC2SPacket packet, CallbackInfo ci) {
+        invokeActEvent(packet);
+    }
+
+    @Inject(method = "onPlayerInteractBlock", at = @At("RETURN"))
+    public void onPlayerInteractBlock(PlayerInteractBlockC2SPacket packet, CallbackInfo ci) {
+        invokeActEvent(packet);
+    }
+
+    @Inject(method = "onPlayerInteractItem", at = @At("RETURN"))
+    public void onPlayerInteractItem(PlayerInteractItemC2SPacket packet, CallbackInfo ci) {
+        invokeActEvent(packet);
+    }
+
+    @Inject(method = "onBoatPaddleState", at = @At("RETURN"))
+    public void onBoatPaddleState(BoatPaddleStateC2SPacket packet, CallbackInfo ci) {
+        invokeActEvent(packet);
+    }
+}

--- a/src/main/resources/assets/essential_commands/lang/en_us.json
+++ b/src/main/resources/assets/essential_commands/lang/en_us.json
@@ -59,6 +59,9 @@
   "cmd.list.feedback.empty": "No locations found.",
   "cmd.top.location_name": "world surface",
 
+  "player.afk.enter": "${0} is now AFK.",
+  "player.afk.exit": "${0} is no longer AFK.",
+
   "teleport.error.interdimensional_teleport_disabled": "Teleport failed. Reason: Interdimensional teleportation disabled.",
   "teleport.queued": "Teleporting to ${0} in ${1} seconds...",
   "teleport.done": "Teleported to ${0}.",

--- a/src/main/resources/essential_commands.mixins.json
+++ b/src/main/resources/essential_commands.mixins.json
@@ -7,6 +7,7 @@
     "PlayerEntityMixin",
     "PlayerManagerMixin",
     "ServerPlayerEntityMixin",
+    "ServerPlayNetworkHandlerMixin",
     "ServerScoreboardMixin",
     "TeleportCommandMixin",
     "WorldSaveHandlerMixin"


### PR DESCRIPTION
- Auto exit on move
- defaultPermissionLevel 0
- Config Options: `ENABLE_AFK` (bool, default true), `AFK_PREFIX` (Text)
- Make TeleportRequestManager a proper singleton
- Add `TICK_EVENT` in PlayerDataManager. Use this instead of server tick event for TeleportRequestManager.
- lang keys: `player.afk.enter`, `player.afk.exit`