### PR TITLE
quick and dirty 1.20 port

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx2048M
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develup
-minecraft_version=1.19.4
-yarn_mappings=1.19.4+build.1
-loader_version=0.14.17
+minecraft_version=1.20-rc1
+yarn_mappings=1.20-rc1+build.2
+loader_version=0.14.21
 
 #Fabric api
-fabric_version=0.76.0+1.19.4
+fabric_version=0.83.0+1.20
 
 # Mod Properties
 mod_name = Essential Commands
@@ -21,7 +21,7 @@ archives_base_name = essential_commands
 # Dependencies
 permissions_api_version=0.2-SNAPSHOT
 placeholder_api_version=2.0.0-pre.2+1.19.3
-pal_version=1.7.0
+pal_version=1.8.0
 
 jetbrains_annotations_version = 22.0.0
 junit_jupiter_version = 5.8.2

--- a/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
+++ b/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
@@ -444,7 +444,7 @@ public final class EssentialCommandRegistry {
                                 context.getSource().sendError(Text.of("No player with the specified name found."));
                                 return;
                             }
-                            context.getSource().sendFeedback(
+                            context.getSource().sendFeedback(() ->
                                 Text.of(playerEntity.getPos().toString()),
                                 EssentialCommands.CONFIG.BROADCAST_TO_OPS);
                         });
@@ -500,7 +500,7 @@ public final class EssentialCommandRegistry {
                     BACKING_CONFIG.loadOrCreateProperties();
                     var player = context.getSource().getPlayer();
                     var ecText = player != null ? ECText.access(player) : ECText.getInstance();
-                    context.getSource().sendFeedback(
+                    context.getSource().sendFeedback(() -> 
                         ecText.getText("cmd.config.reload"),
                         true
                     );
@@ -512,7 +512,7 @@ public final class EssentialCommandRegistry {
                 .requires(ECPerms.require(ECPerms.Registry.config_reload, 4))
                 .executes((context) -> {
                     BACKING_CONFIG.loadOrCreateProperties();
-                    context.getSource().sendFeedback(
+                    context.getSource().sendFeedback(() -> 
                         BACKING_CONFIG.stateAsText(),
                         false
                     );
@@ -522,9 +522,10 @@ public final class EssentialCommandRegistry {
                     .suggests(ListSuggestion.of(BACKING_CONFIG::getPublicFieldNames))
                     .executes(context -> {
                         try {
-                            context.getSource().sendFeedback(BACKING_CONFIG.getFieldValueAsText(
-                                StringArgumentType.getString(context, "config_property")
-                            ), false);
+                            Text t =  BACKING_CONFIG.getFieldValueAsText(
+                                    StringArgumentType.getString(context, "config_property"));
+                            context.getSource().sendFeedback(() -> t
+                            , false);
                         } catch (NoSuchFieldException e) {
                             e.printStackTrace();
                         }
@@ -547,7 +548,7 @@ public final class EssentialCommandRegistry {
                             mcDir.resolve("world/modplayerdata").toFile(),
                             source.getSource().getServer()
                         );
-                        source.getSource().sendFeedback(Text.literal("Successfully converted data dirs."), CONFIG.BROADCAST_TO_OPS);
+                        source.getSource().sendFeedback(() -> Text.literal("Successfully converted data dirs."), CONFIG.BROADCAST_TO_OPS);
                     } catch (NotDirectoryException | FileNotFoundException e) {
                         e.printStackTrace();
                     }
@@ -562,7 +563,7 @@ public final class EssentialCommandRegistry {
                         source.getSource().getServer(),
                         mcDir.resolve("plugins/Essentials/warps").toFile()
                     );
-                    source.getSource().sendFeedback(Text.literal("Successfully converted warps."), CONFIG.BROADCAST_TO_OPS);
+                    source.getSource().sendFeedback(() -> Text.literal("Successfully converted warps."), CONFIG.BROADCAST_TO_OPS);
                     return 0;
                 }).build()
             );

--- a/src/main/java/com/fibermc/essentialcommands/commands/GametimeCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/GametimeCommand.java
@@ -26,10 +26,11 @@ public class GametimeCommand implements Command<ServerCommandSource> {
 
     @Override
     public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        context.getSource().sendFeedback(
-            getFormattedTime(
+        Text t = getFormattedTime(
                 context.getSource().getWorld().getTimeOfDay(),
-                PlayerProfile.accessFromContextOrThrow(context)),
+                PlayerProfile.accessFromContextOrThrow(context));
+        context.getSource().sendFeedback(() -> t
+            ,
             false);
 
         return 0;

--- a/src/main/java/com/fibermc/essentialcommands/commands/HomeTeleportOtherCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/HomeTeleportOtherCommand.java
@@ -99,7 +99,7 @@ public class HomeTeleportOtherCommand extends HomeCommand implements Command<Ser
                     senderPlayerProfile
                 );
 
-                context.getSource().sendFeedback(
+                context.getSource().sendFeedback(() ->
                     suggestionText,
                     CONFIG.BROADCAST_TO_OPS
                 );

--- a/src/main/java/com/fibermc/essentialcommands/commands/ListCommandFactory.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/ListCommandFactory.java
@@ -36,7 +36,7 @@ public final class ListCommandFactory {
             var styleProvider = PlayerProfile.accessFromContextOrThrow(context);
             Collection<Entry<String, T>> suggestionsList = suggestionsProvider.getSuggestionList(context);
 
-            context.getSource().sendFeedback(
+            context.getSource().sendFeedback(() ->
                 getSuggestionText(responsePreText, commandExecText, suggestionsList, styleProvider),
                 CONFIG.BROADCAST_TO_OPS
             );

--- a/src/main/java/com/fibermc/essentialcommands/commands/MotdCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/MotdCommand.java
@@ -26,6 +26,6 @@ public final class MotdCommand {
             TextParserUtils.formatText(CONFIG.MOTD),
             PlaceholderContext.of(player)
         );
-        player.getCommandSource().sendFeedback(message, false);
+        player.getCommandSource().sendFeedback(() -> message, false);
     }
 }

--- a/src/main/java/com/fibermc/essentialcommands/commands/ProfileCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/ProfileCommand.java
@@ -42,7 +42,7 @@ public final class ProfileCommand {
                 .executes((context) -> {
                     var player = context.getSource().getPlayerOrThrow();
                     var profile = ((ServerPlayerEntityAccess) player).ec$getProfile();
-                    context.getSource().sendFeedback(
+                    context.getSource().sendFeedback(() ->
                         Text.literal(option.profileGetter().getValue(profile).toString()),
                         CONFIG.BROADCAST_TO_OPS);
                     return 0;

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -17,7 +17,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Material;
+import net.minecraft.block.Blocks;
 import net.minecraft.command.CommandException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -106,7 +106,7 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
         // TODO This should be memoized. Cuts exec time in 1/2.
         BlockState targetBlockState = world.getBlockState(new BlockPos(x, y, z));
         BlockState footBlockState = world.getBlockState(new BlockPos(x, y - 1, z));
-        return targetBlockState.isAir() && footBlockState.getMaterial().isSolid();
+        return targetBlockState.isAir() && footBlockState.isSolid();
     }
 
     private static int exec(ServerCommandSource source, ServerWorld world) throws CommandSyntaxException {
@@ -189,8 +189,8 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
             return false;
         }
 
-        var material = chunk.getBlockState(pos).getMaterial();
-        return pos.getY() < maxY.get() && !material.isLiquid() && material != Material.FIRE;
+        BlockState blockState = chunk.getBlockState(pos);
+        return pos.getY() < maxY.get() && blockState.getFluidState().isEmpty() && blockState.getBlock() != Blocks.FIRE;
     }
 
 }

--- a/src/main/java/com/fibermc/essentialcommands/commands/RealNameCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RealNameCommand.java
@@ -42,7 +42,7 @@ public class RealNameCommand implements Command<ServerCommandSource> {
             }
         }
 
-        context.getSource().sendFeedback(responseText, CONFIG.BROADCAST_TO_OPS);
+        context.getSource().sendFeedback(() -> responseText, CONFIG.BROADCAST_TO_OPS);
 
         return 0;
     }

--- a/src/main/java/com/fibermc/essentialcommands/commands/RulesCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RulesCommand.java
@@ -23,7 +23,7 @@ public final class RulesCommand {
     private static Text rulesText;
 
     public static int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        context.getSource().sendFeedback(rulesText, false);
+        context.getSource().sendFeedback(() -> rulesText, false);
         return 0;
     }
 

--- a/src/main/java/com/fibermc/essentialcommands/commands/helpers/FeedbackReceiver.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/helpers/FeedbackReceiver.java
@@ -26,7 +26,7 @@ public final class FeedbackReceiver implements IFeedbackReceiver {
 
     @Override
     public void sendCommandFeedback(Text text) {
-        commandSource.sendFeedback(text, CONFIG.BROADCAST_TO_OPS);
+        commandSource.sendFeedback(() -> text, CONFIG.BROADCAST_TO_OPS);
     }
 
     @Override

--- a/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
@@ -33,9 +33,6 @@ import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends PlayerEntityMixin implements ServerPlayerEntityAccess {
 
-    @Shadow
-    public abstract ServerWorld getWorld();
-
     @Unique
     public QueuedTeleport ecQueuedTeleport;
 

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
@@ -162,7 +162,7 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
     }
 
     public void sendCommandFeedback(Text text) {
-        this.player.getCommandSource().sendFeedback(text, CONFIG.BROADCAST_TO_OPS);
+        this.player.getCommandSource().sendFeedback(() -> text, CONFIG.BROADCAST_TO_OPS);
     }
 
     public void sendCommandFeedback(String messageKey, Text... args) {

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataManager.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataManager.java
@@ -217,7 +217,7 @@ public class PlayerDataManager {
             // This event handler executes just before the player is truly respawned, so we can just
             // modify the entity's location to achieve this.
             newPlayerEntity.setPosition(spawnLoc.pos());
-            newPlayerEntity.setWorld(newPlayerEntity.getServer().getWorld(spawnLoc.dim()));
+            newPlayerEntity.setServerWorld(newPlayerEntity.getServer().getWorld(spawnLoc.dim()));
         }
     }
 


### PR DESCRIPTION
A very mechanical port to 1.20 based on suggestions from the Fabric team here https://fabricmc.net/2023/05/25/120.html. We did it to allow us to start testing for a server update to 1.20. Feel free to use it any way you want.

Mainly it is updating calls to sendFeedback() to pass a Supplier<Text> instead of a Text parameter.

The changes to handle the removal of Material are not fully tested. The isSolid() call is marked as deprecated, so that should probably be something else.