### PR TITLE
Make spectator mode player cannot back to the previous location

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
@@ -33,6 +33,9 @@ import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends PlayerEntityMixin implements ServerPlayerEntityAccess {
 
+    @Shadow
+    public abstract boolean isSpectator();
+
     @Unique
     public QueuedTeleport ecQueuedTeleport;
 
@@ -162,7 +165,9 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntityMixin implemen
     // Teleport hook (for /back)
     @Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDFF)V", at = @At("HEAD"))
     public void onTeleport(ServerWorld targetWorld, double x, double y, double z, float yaw, float pitch, CallbackInfo ci) {
-        this.ec$getPlayerData().setPreviousLocation(new MinecraftLocation((ServerPlayerEntity) (Object) this));
+        if (!isSpectator()) {
+            this.ec$getPlayerData().setPreviousLocation(new MinecraftLocation((ServerPlayerEntity) (Object) this));
+        }
     }
 
     @Inject(method = "enterCombat", at = @At("RETURN"))

--- a/src/main/java/com/fibermc/essentialcommands/mixin/TeleportCommandMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/TeleportCommandMixin.java
@@ -39,7 +39,9 @@ public class TeleportCommandMixin {
             // This cast is guaranteed to work because of where we inject.
             var targetPlayer = (ServerPlayerEntity)target;
             var targetPlayerData = ((ServerPlayerEntityAccess)target).ec$getPlayerData();
-            targetPlayerData.setPreviousLocation(new MinecraftLocation(targetPlayer));
+            if (!targetPlayer.isSpectator()) {
+                targetPlayerData.setPreviousLocation(new MinecraftLocation(targetPlayer));
+            }
         }
     }
 }


### PR DESCRIPTION
I know that doing so may violate the expected effect of the/back command at the beginning. However, as far as I know, many servers have mods that allow all players to switch spectator mode, so that players can view actions or visit each other by this. However, if the **/back** command is still work at this time, the player may be able to cross the wall or reach an unreachable position (the specific method is: first switch to spectator mode, and then switch back to the survival mode after the completion of the wall crossing (at this time, the mod responsible for switching the player mode will pull the player back to the original location), and then use the **/back** command to return to the position after the wall crossing). Therefore, I want to make this change.