### PR TITLE
feat: RTP enhancements (make it work in the Nether!) (and more!)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ allprojects {
 
         maven {
             name = 'Ladysnake Mods'
-            url = 'https://ladysnake.jfrog.io/artifactory/mods'
+            url = 'https://maven.ladysnake.org/releases'
             content {
                 includeGroup 'io.github.ladysnake'
                 includeGroupByRegex 'io\\.github\\.onyxstudios.*'

--- a/src/main/java/com/fibermc/essentialcommands/ECPerms.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECPerms.java
@@ -67,6 +67,7 @@ public final class ECPerms {
         public static final String bypass_allow_teleport_between_dimensions = "essentialcommands.bypass.allow_teleport_between_dimensions";
         public static final String bypass_teleport_interrupt_on_damaged = "essentialcommands.bypass.teleport_interrupt_on_damaged";
         public static final String bypass_teleport_interrupt_on_move = "essentialcommands.bypass.teleport_interrupt_on_move";
+        public static final String bypass_randomteleport_cooldown = "essentialcommands.bypass.randomteleport_cooldown";
         public static final String rules_reload = "essentialcommands.rules_reload";
         public static final String rules = "essentialcommands.rules";
         public static final String motd = "essentialcommands.motd";

--- a/src/main/java/com/fibermc/essentialcommands/EssentialCommands.java
+++ b/src/main/java/com/fibermc/essentialcommands/EssentialCommands.java
@@ -38,6 +38,10 @@ public final class EssentialCommands implements ModInitializer {
         LOGGER.log(level, logPrefix.concat(message), args);
     }
 
+    public static void refreshConfigSnapshot() {
+        CONFIG = EssentialCommandsConfigSnapshot.create(BACKING_CONFIG);
+    }
+
     @Override
     public void onInitialize() {
         if (MOD_METADATA == null) {

--- a/src/main/java/com/fibermc/essentialcommands/ManagerLocator.java
+++ b/src/main/java/com/fibermc/essentialcommands/ManagerLocator.java
@@ -1,17 +1,24 @@
 package com.fibermc.essentialcommands;
 
+import java.util.HashMap;
+import java.util.function.Consumer;
+
 import com.fibermc.essentialcommands.commands.suggestions.OfflinePlayerRepo;
 import com.fibermc.essentialcommands.playerdata.PlayerDataManager;
 import com.fibermc.essentialcommands.teleportation.TeleportManager;
 
 import net.minecraft.server.MinecraftServer;
 
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+
 public final class ManagerLocator {
 
+    private MinecraftServer server;
     private PlayerDataManager playerDataManager;
     private TeleportManager tpManager;
     private WorldDataManager worldDataManager;
     private OfflinePlayerRepo offlinePlayerRepo;
+    private final HashMap<String, Consumer<MinecraftServer>> serverStartActions = new HashMap<>();
 
     public static ManagerLocator instance;
 
@@ -29,11 +36,18 @@ public final class ManagerLocator {
         TeleportManager.init();
     }
 
+    private boolean serverStarted = false;
+
     public void onServerStart(MinecraftServer server) {
+        this.server = server;
         this.playerDataManager = PlayerDataManager.getInstance();
         this.tpManager = TeleportManager.getInstance();
         this.worldDataManager = WorldDataManager.createForServer(server);
         this.offlinePlayerRepo = new OfflinePlayerRepo(server);
+        ServerLifecycleEvents.SERVER_STARTED.register(server1 -> {
+            serverStartActions.values().forEach(a -> a.accept(server));
+            serverStarted = true;
+        });
     }
 
     public PlayerDataManager getPlayerDataManager() {
@@ -50,5 +64,13 @@ public final class ManagerLocator {
 
     public OfflinePlayerRepo getOfflinePlayerRepo() {
         return offlinePlayerRepo;
+    }
+
+    public void runAndQueue(String key, Consumer<MinecraftServer> action) {
+        serverStartActions.putIfAbsent(key, action);
+
+        if (this.serverStarted) {
+            action.accept(this.server);
+        }
     }
 }

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -9,7 +9,6 @@ import java.util.concurrent.Executors;
 
 import com.fibermc.essentialcommands.EssentialCommands;
 import com.fibermc.essentialcommands.ManagerLocator;
-import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
 import com.fibermc.essentialcommands.commands.helpers.HeightFinder;
 import com.fibermc.essentialcommands.commands.helpers.HeightFindingStrategy;
 import com.fibermc.essentialcommands.playerdata.PlayerData;
@@ -77,9 +76,8 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
 
         //TODO Add OP/Permission bypass for RTP cooldown.
         if (CONFIG.RTP_COOLDOWN > 0) {
-            ServerCommandSource source = context.getSource();
-            int curServerTickTime = source.getServer().getTicks();
-            PlayerData playerData = ((ServerPlayerEntityAccess) player).ec$getPlayerData();
+            int curServerTickTime = context.getSource().getServer().getTicks();
+            var playerData = PlayerData.access(player);
             var rtpCooldownEndTime = playerData.getTimeUsedRtp() + CONFIG.RTP_COOLDOWN * 20;
             var rtpCooldownRemaining = rtpCooldownEndTime - curServerTickTime;
             if (rtpCooldownRemaining > 0) {

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import com.fibermc.essentialcommands.ECPerms;
 import com.fibermc.essentialcommands.EssentialCommands;
 import com.fibermc.essentialcommands.ManagerLocator;
 import com.fibermc.essentialcommands.commands.helpers.HeightFinder;
@@ -75,7 +76,7 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
 //        }
 
         //TODO Add OP/Permission bypass for RTP cooldown.
-        if (CONFIG.RTP_COOLDOWN > 0) {
+        if (CONFIG.RTP_COOLDOWN > 0 && !ECPerms.check(context.getSource(), ECPerms.Registry.bypass_randomteleport_cooldown)) {
             int curServerTickTime = context.getSource().getServer().getTicks();
             var playerData = PlayerData.access(player);
             var rtpCooldownEndTime = playerData.getTimeUsedRtp() + CONFIG.RTP_COOLDOWN * 20;

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -116,13 +116,6 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
         return 1;
     }
 
-    private static boolean isValidSpawnPosition(ServerWorld world, int x, int y, int z) {
-        // TODO This should be memoized. Cuts exec time in 1/2.
-        BlockState targetBlockState = world.getBlockState(new BlockPos(x, y, z));
-        BlockState footBlockState = world.getBlockState(new BlockPos(x, y - 1, z));
-        return targetBlockState.isAir() && footBlockState.isSolid();
-    }
-
     private static final ThreadLocal<Integer> maxY = new ThreadLocal<>();
 
     private static void exec(ServerPlayerEntity player, ServerWorld world) {

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -161,7 +161,7 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
     }
 
     private static Optional<BlockPos> findRtpPosition(ServerWorld world, Vec3i center, HeightFinder heightFinder) {
-        maxY.set(world.getHeight()); // TODO: Per-world, preset maximums (or some other mechanism of making this work in the nether)
+        maxY.set(world.getTopY()); // TODO: Per-world, preset maximums (or some other mechanism of making this work in the nether)
 
         // Search for a valid y-level (not in a block, underwater, out of the world, etc.)
         final BlockPos targetXZ = getRandomXZ(center);

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -29,6 +29,7 @@ import net.minecraft.command.CommandException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Vec3i;
@@ -67,10 +68,11 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
         ServerPlayerEntity player = context.getSource().getPlayerOrThrow();
         ServerWorld world = context.getSource().getWorld();
         var ecText = ECText.access(player);
-        if (CONFIG.RTP_ENABLED_WORLDS.contains(world.getRegistryKey())) {
+        if (!CONFIG.RTP_ENABLED_WORLDS.contains(world.getRegistryKey())) {
+            var currentWorldAsText = Text.of(world.getRegistryKey().getValue().toString());
             throw new CommandException(TextUtil.concat(
                 ecText.getText("cmd.rtp.error.pre", TextFormatType.Error),
-                ecText.getText("cmd.rtp.error.not_overworld", TextFormatType.Error)
+                ecText.getText("cmd.rtp.error.world_not_enabled", TextFormatType.Error, currentWorldAsText)
             ));
         }
 

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -75,7 +75,6 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
 //            ));
 //        }
 
-        //TODO Add OP/Permission bypass for RTP cooldown.
         if (CONFIG.RTP_COOLDOWN > 0 && !ECPerms.check(context.getSource(), ECPerms.Registry.bypass_randomteleport_cooldown)) {
             int curServerTickTime = context.getSource().getServer().getTicks();
             var playerData = PlayerData.access(player);

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -1,11 +1,17 @@
 package com.fibermc.essentialcommands.commands;
 
+import java.util.Iterator;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Random;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import com.fibermc.essentialcommands.EssentialCommands;
 import com.fibermc.essentialcommands.ManagerLocator;
 import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
+import com.fibermc.essentialcommands.commands.helpers.HeightFinder;
+import com.fibermc.essentialcommands.commands.helpers.HeightFindingStrategy;
 import com.fibermc.essentialcommands.playerdata.PlayerData;
 import com.fibermc.essentialcommands.teleportation.PlayerTeleporter;
 import com.fibermc.essentialcommands.text.ECText;
@@ -24,14 +30,13 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Vec3i;
-import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 
 import dev.jpcode.eccore.util.TextUtil;
 
 import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
-import static com.fibermc.essentialcommands.commands.TopCommand.getTop;
 
 /**
  * <p>
@@ -48,17 +53,29 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
 
     public RandomTeleportCommand() {}
 
+    private Thread.UncaughtExceptionHandler exceptionHandler = (thread, throwable) -> {
+        EssentialCommands.LOGGER.error("Exception in RTP calculator thread", throwable);
+    };
+    private Executor threadExecutor = Executors.newCachedThreadPool(runnable -> {
+        var thread = new Thread(runnable, "RTP Location Calculator Thread");
+
+        thread.setUncaughtExceptionHandler(exceptionHandler);
+
+        return thread;
+    });
+
     @Override
     public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerPlayerEntity player = context.getSource().getPlayerOrThrow();
         ServerWorld world = context.getSource().getWorld();
         var ecText = ECText.access(player);
-        if (!world.getRegistryKey().equals(World.OVERWORLD)) {
-            throw new CommandException(TextUtil.concat(
-                ecText.getText("cmd.rtp.error.pre", TextFormatType.Error),
-                ecText.getText("cmd.rtp.error.not_overworld", TextFormatType.Error)
-            ));
-        }
+        // FIXME @jp: [BEFORE MERGE] - Config option for applicable world registry keys
+//        if (world.getRegistryKey() != World.OVERWORLD) {
+//            throw new CommandException(TextUtil.concat(
+//                ecText.getText("cmd.rtp.error.pre", TextFormatType.Error),
+//                ecText.getText("cmd.rtp.error.not_overworld", TextFormatType.Error)
+//            ));
+//        }
 
         //TODO Add OP/Permission bypass for RTP cooldown.
         if (CONFIG.RTP_COOLDOWN > 0) {
@@ -79,26 +96,32 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
             playerData.setTimeUsedRtp(curServerTickTime);
         }
 
-        new Thread("RTP Location Calculator Thread") {
-            public void run() {
-                try {
-                    {
-                        Stopwatch timer = Stopwatch.createStarted();
+        threadExecutor.execute(() -> {
+            EssentialCommands.LOGGER.info(
+                String.format(
+                    "Starting RTP location search for %s",
+                    player.getGameProfile().getName()
+                ));
+            {
+                Stopwatch timer = Stopwatch.createStarted();
 
-                        exec(context.getSource(), world);
-
-                        var totalTime = timer.stop();
-                        EssentialCommands.LOGGER.info(
-                            String.format(
-                                "Total RTP Time: %s",
-                                totalTime
-                            ));
-                    }
+                try {// this exec should be removed, and so shoudl this
+                // trycatch, prolly... I think... maybe.. depends on if the one
+                // that accepts ServerPlayerEntity _needs_ to have no feedback
+                    exec(context.getSource(), world);
                 } catch (CommandSyntaxException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
+
+                var totalTime = timer.stop();
+                EssentialCommands.LOGGER.info(
+                    String.format(
+                        "Total RTP Time: %s",
+                        totalTime
+                    ));
             }
-        }.start();
+        });
+
         return 1;
     }
 
@@ -127,13 +150,15 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
     private static final ThreadLocal<Integer> maxY = new ThreadLocal<>();
 
     private static int exec(ServerPlayerEntity player, ServerWorld world, Vec3i center) {
-        var ecText = ECText.access(player);
+        final var ecText = ECText.access(player);
+
+        final var heightFinder = HeightFindingStrategy.forWorld(world.getRegistryKey());
 
         int timesRun = 0;
         Optional<BlockPos> pos;
         do {
             timesRun++;
-            pos = findRtpPosition(world, center);
+            pos = findRtpPosition(world, center, heightFinder);
         } while (pos.isEmpty() && timesRun <= CONFIG.RTP_MAX_ATTEMPTS);
 
         if (pos.isEmpty()) {
@@ -150,23 +175,32 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
         return 1;
     }
 
-    private static Optional<BlockPos> findRtpPosition(ServerWorld world, Vec3i center) {
+    private static Optional<BlockPos> findRtpPosition(ServerWorld world, Vec3i center, HeightFinder heightFinder) {
         maxY.set(world.getHeight()); // TODO: Per-world, preset maximums (or some other mechanism of making this work in the nether)
 
         // Search for a valid y-level (not in a block, underwater, out of the world, etc.)
         final BlockPos targetXZ = getRandomXZ(center);
-        final int x = targetXZ.getX();
-        final int z = targetXZ.getZ();
         final Chunk chunk = world.getChunk(targetXZ);
-        final int y = getTop(chunk, x, z);
+
+        for (BlockPos.Mutable candidateBlock : getChunkCandidateBlocks(chunk.getPos())) {
+            final int x = candidateBlock.getX();
+            final int z = candidateBlock.getZ();
+            final OptionalInt yOpt = heightFinder.getY(chunk, x, z);
+            if (yOpt.isEmpty()) {
+                continue;
+            }
+            final int y = yOpt.getAsInt();
+
+            // This creates an infinite recursive call in the case where all positions on RTP circle are in water.
+            //  Addressed by adding timesRun limit.
+            if (isSafePosition(chunk, new BlockPos(x, y - 2, z))) {
+                return Optional.of(new BlockPos(x, y, z));
+            }
+        }
 
         // This creates an infinite recursive call in the case where all positions on RTP circle are in water.
         //  Addressed by adding timesRun limit.
-        if (!isSafePosition(chunk, new BlockPos(x, y - 2, z))) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new BlockPos(x, y, z));
+        return Optional.empty();
     }
 
     private static BlockPos getRandomXZ(Vec3i center) {
@@ -193,6 +227,31 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
 
         BlockState blockState = chunk.getBlockState(pos);
         return pos.getY() < maxY.get() && blockState.getFluidState().isEmpty() && blockState.getBlock() != Blocks.FIRE;
+    }
+
+    public static Iterable<BlockPos.Mutable> getChunkCandidateBlocks(ChunkPos chunkPos) {
+        return () -> new Iterator<>() {
+            private int _idx = -1;
+            private BlockPos.Mutable _pos = new BlockPos.Mutable();
+
+            @Override
+            public boolean hasNext() {
+                return _idx < 4;
+            }
+
+            @Override
+            public BlockPos.Mutable next() {
+                _idx++;
+                return switch (_idx) {
+                    case 0 -> _pos.set(chunkPos.getStartX(), 0, chunkPos.getStartZ());
+                    case 1 -> _pos.set(chunkPos.getStartX(), 0, chunkPos.getEndZ());
+                    case 2 -> _pos.set(chunkPos.getEndX(), 0, chunkPos.getStartZ());
+                    case 3 -> _pos.set(chunkPos.getEndX(), 0, chunkPos.getEndZ());
+                    case 4 -> _pos.set(chunkPos.getCenterX(), 0, chunkPos.getCenterZ());
+                    default -> throw new IllegalStateException("Unexpected value: " + _idx);
+                };
+            }
+        };
     }
 
 }

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -67,13 +67,12 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
         ServerPlayerEntity player = context.getSource().getPlayerOrThrow();
         ServerWorld world = context.getSource().getWorld();
         var ecText = ECText.access(player);
-        // FIXME @jp: [BEFORE MERGE] - Config option for applicable world registry keys
-//        if (world.getRegistryKey() != World.OVERWORLD) {
-//            throw new CommandException(TextUtil.concat(
-//                ecText.getText("cmd.rtp.error.pre", TextFormatType.Error),
-//                ecText.getText("cmd.rtp.error.not_overworld", TextFormatType.Error)
-//            ));
-//        }
+        if (CONFIG.RTP_ENABLED_WORLDS.contains(world.getRegistryKey())) {
+            throw new CommandException(TextUtil.concat(
+                ecText.getText("cmd.rtp.error.pre", TextFormatType.Error),
+                ecText.getText("cmd.rtp.error.not_overworld", TextFormatType.Error)
+            ));
+        }
 
         if (CONFIG.RTP_COOLDOWN > 0 && !ECPerms.check(context.getSource(), ECPerms.Registry.bypass_randomteleport_cooldown)) {
             int curServerTickTime = context.getSource().getServer().getTicks();

--- a/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RandomTeleportCommand.java
@@ -38,25 +38,23 @@ import dev.jpcode.eccore.util.TextUtil;
 
 import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 
-/**
- * <p>
+/*
  * Heavily referenced from
  * https://github.com/javachaos/randomteleport/blob/master/src/main/java/net.ethermod/commands/RandomTeleportCommand.java
- * </p>
- * <p>
+ *
  * Additionally, tons of optimization tips & examples provided by @Wesley1808 on GitHub:
  * https://github.com/Wesley1808/ServerCore/issues/16
- * </p>
+ *
  */
 @SuppressWarnings("checkstyle:all")
 public class RandomTeleportCommand implements Command<ServerCommandSource> {
 
     public RandomTeleportCommand() {}
 
-    private Thread.UncaughtExceptionHandler exceptionHandler = (thread, throwable) -> {
+    private final Thread.UncaughtExceptionHandler exceptionHandler = (thread, throwable) -> {
         EssentialCommands.LOGGER.error("Exception in RTP calculator thread", throwable);
     };
-    private Executor threadExecutor = Executors.newCachedThreadPool(runnable -> {
+    private final Executor threadExecutor = Executors.newCachedThreadPool(runnable -> {
         var thread = new Thread(runnable, "RTP Location Calculator Thread");
 
         thread.setUncaughtExceptionHandler(exceptionHandler);
@@ -225,7 +223,7 @@ public class RandomTeleportCommand implements Command<ServerCommandSource> {
     public static Iterable<BlockPos.Mutable> getChunkCandidateBlocks(ChunkPos chunkPos) {
         return () -> new Iterator<>() {
             private int _idx = -1;
-            private BlockPos.Mutable _pos = new BlockPos.Mutable();
+            private final BlockPos.Mutable _pos = new BlockPos.Mutable();
 
             @Override
             public boolean hasNext() {

--- a/src/main/java/com/fibermc/essentialcommands/commands/TopCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/TopCommand.java
@@ -1,5 +1,7 @@
 package com.fibermc.essentialcommands.commands;
 
+import java.util.OptionalInt;
+
 import com.fibermc.essentialcommands.teleportation.PlayerTeleporter;
 import com.fibermc.essentialcommands.text.ECText;
 import com.fibermc.essentialcommands.types.MinecraftLocation;
@@ -25,7 +27,7 @@ public class TopCommand implements Command<ServerCommandSource> {
         World world = source.getWorld();
         BlockPos playerPos = player.getBlockPos();
 
-        int new_y;
+        OptionalInt new_y;
         int new_x = playerPos.getX();
         int new_z = playerPos.getZ();
 
@@ -34,21 +36,25 @@ public class TopCommand implements Command<ServerCommandSource> {
         Chunk chunk = world.getChunk(targetXZ);
         new_y = getTop(chunk, new_x, new_z);
 
+        if (new_y.isEmpty()) {
+            // TODO: err msg
+            return -1;
+        }
         // Teleport the player
         PlayerTeleporter.requestTeleport(
             player,
-            new MinecraftLocation(world.getRegistryKey(), new_x, new_y, new_z, player.getHeadYaw(), player.getPitch()),
+            new MinecraftLocation(world.getRegistryKey(), new_x, new_y.getAsInt(), new_z, player.getHeadYaw(), player.getPitch()),
             ECText.access(player).getText("cmd.top.location_name")
         );
 
         return 0;
     }
 
-    public static int getTop(Chunk chunk, int x, int z) {
+    public static OptionalInt getTop(Chunk chunk, int x, int z) {
         final int maxY = calculateMaxY(chunk);
         final int bottomY = chunk.getBottomY();
         if (maxY <= bottomY) {
-            return Integer.MIN_VALUE;
+            return OptionalInt.empty();
         }
 
         final BlockPos.Mutable mutablePos = new BlockPos.Mutable(x, maxY, z);
@@ -59,14 +65,14 @@ public class TopCommand implements Command<ServerCommandSource> {
         while (mutablePos.getY() > bottomY) {
             isAir3 = chunk.getBlockState(mutablePos.move(Direction.DOWN)).isAir();
             if (!isAir3 && isAir2 && isAir1) { // If there is a floor block and space for player body+head
-                return mutablePos.getY() + 1;
+                return OptionalInt.of(mutablePos.getY() + 1);
             }
 
             isAir1 = isAir2;
             isAir2 = isAir3;
         }
 
-        return Integer.MIN_VALUE;
+        return OptionalInt.empty();
     }
 
     private static int calculateMaxY(Chunk chunk) {

--- a/src/main/java/com/fibermc/essentialcommands/commands/TopCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/TopCommand.java
@@ -76,7 +76,7 @@ public class TopCommand implements Command<ServerCommandSource> {
     }
 
     private static int calculateMaxY(Chunk chunk) {
-        final int maxY = chunk.getHeight();
+        final int maxY = chunk.getTopY();
         ChunkSection[] sections = chunk.getSectionArray();
         int maxSectionIndex = Math.min(sections.length - 1, maxY >> 4);
 

--- a/src/main/java/com/fibermc/essentialcommands/commands/helpers/HeightFinder.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/helpers/HeightFinder.java
@@ -1,0 +1,11 @@
+package com.fibermc.essentialcommands.commands.helpers;
+
+import java.util.OptionalInt;
+
+import net.minecraft.world.chunk.Chunk;
+
+@FunctionalInterface
+public interface HeightFinder {
+    OptionalInt getY(Chunk chunk, int x, int z);
+}
+

--- a/src/main/java/com/fibermc/essentialcommands/commands/helpers/HeightFinder.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/helpers/HeightFinder.java
@@ -6,6 +6,11 @@ import net.minecraft.world.chunk.Chunk;
 
 @FunctionalInterface
 public interface HeightFinder {
+    /**
+     * Attempts to find a safe surface Y value for the specified X & Z values.
+     *
+     * @return A Y value corresponding to the player's feet pos
+     */
     OptionalInt getY(Chunk chunk, int x, int z);
 }
 

--- a/src/main/java/com/fibermc/essentialcommands/commands/helpers/HeightFindingStrategy.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/helpers/HeightFindingStrategy.java
@@ -1,0 +1,73 @@
+package com.fibermc.essentialcommands.commands.helpers;
+
+import java.util.OptionalInt;
+
+import com.fibermc.essentialcommands.commands.TopCommand;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+public enum HeightFindingStrategy implements HeightFinder {
+    SKY_TO_SURFACE__FIRST_SOLID(TopCommand::getTop),
+    BOTTOM_TO_SKY__FIRST_SAFE_AIR(HeightFindingStrategy::findYBottomUp),
+    ;
+
+    private final HeightFinder _heightFinder;
+
+    HeightFindingStrategy(HeightFinder heightFinder) {
+
+        this._heightFinder = heightFinder;
+    }
+
+    public static HeightFindingStrategy forWorld(RegistryKey<World> worldRegistryKey) {
+        if (worldRegistryKey == World.OVERWORLD || worldRegistryKey == World.END) {
+            return HeightFindingStrategy.SKY_TO_SURFACE__FIRST_SOLID;
+        }
+        if (worldRegistryKey == World.NETHER) {
+            return HeightFindingStrategy.BOTTOM_TO_SKY__FIRST_SAFE_AIR;
+        }
+
+        // fallback
+        return HeightFindingStrategy.SKY_TO_SURFACE__FIRST_SOLID;
+    }
+
+    @Override
+    public OptionalInt getY(Chunk chunk, int x, int z) {
+        return _heightFinder.getY(chunk, x, z);
+    }
+
+    private static OptionalInt findYBottomUp(Chunk chunk, int x, int z) {
+        final int topY = getChunkHighestNonEmptySectionYOffsetOrTopY(chunk);
+        final int bottomY = chunk.getBottomY();
+        if (topY <= bottomY) {
+            return OptionalInt.empty();
+        }
+
+        final BlockPos.Mutable mutablePos = new BlockPos.Mutable(x, bottomY, z);
+        BlockState bsFeet1 = chunk.getBlockState(mutablePos); // Block below feet
+        BlockState bsBody2 = chunk.getBlockState(mutablePos.move(Direction.UP)); // Block at feet level
+        BlockState bsHead3; // Block at head level
+
+        while (mutablePos.getY() < topY) {
+            bsHead3 = chunk.getBlockState(mutablePos.move(Direction.UP));
+            if (bsFeet1.isSolid() && bsBody2.isAir() && bsHead3.isAir()) { // If there is a floor block and space for player body+head
+                return OptionalInt.of(mutablePos.getY() - 1);
+            }
+
+            bsFeet1 = bsBody2;
+            bsBody2 = bsHead3;
+        }
+
+        return OptionalInt.empty();
+    }
+
+    public static int getChunkHighestNonEmptySectionYOffsetOrTopY(Chunk chunk) {
+        int i = chunk.getHighestNonEmptySection();
+        return i == chunk.getTopY() ? chunk.getBottomY() : ChunkSectionPos.getBlockCoord(chunk.sectionIndexToCoord(i));
+    }
+}

--- a/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
+++ b/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
@@ -137,7 +137,7 @@ public final class EssentialCommandsConfig extends Config<EssentialCommandsConfi
                     .toList();
 
                 if (invalidConfiguredWorldIds.size() > 0) {
-                    EssentialCommands.LOGGER.error("{} configured `rtp_enabled_worlds` world ids were invalid: {}", invalidConfiguredWorldIds.size(), String.join(",", invalidConfiguredWorldIds.stream().map(Identifier::toString).toList()));
+                    EssentialCommands.LOGGER.warn("{} configured `rtp_enabled_worlds` world ids were invalid: {}", invalidConfiguredWorldIds.size(), String.join(",", invalidConfiguredWorldIds.stream().map(Identifier::toString).toList()));
                 } else {
                     EssentialCommands.LOGGER.info("All configured `rtp_enabled_worlds` world ids are valid.");
                 }

--- a/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
+++ b/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
@@ -2,16 +2,24 @@ package com.fibermc.essentialcommands.config;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fibermc.essentialcommands.ECPerms;
+import com.fibermc.essentialcommands.EssentialCommands;
+import com.fibermc.essentialcommands.ManagerLocator;
 import com.fibermc.essentialcommands.playerdata.PlayerDataManager;
 import com.fibermc.essentialcommands.types.RespawnCondition;
 import org.jetbrains.annotations.NotNull;
 
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
 
 import dev.jpcode.eccore.config.Config;
 import dev.jpcode.eccore.config.ConfigOption;
@@ -73,6 +81,7 @@ public final class EssentialCommandsConfig extends Config<EssentialCommandsConfi
     @ConfigOption public final Option<Integer> RTP_MIN_RADIUS =         new Option<>("rtp_min_radius", RTP_RADIUS.getValue(), (String s) -> parseIntOrDefault(s, RTP_RADIUS.getValue()));
     @ConfigOption public final Option<Integer> RTP_COOLDOWN =           new Option<>("rtp_cooldown", 30, ConfigUtil::parseInt);
     @ConfigOption public final Option<Integer> RTP_MAX_ATTEMPTS =       new Option<>("rtp_max_attempts", 15, ConfigUtil::parseInt);
+    @ConfigOption public final Option<List<String>> RTP_ENABLED_WORLDS = new Option<>("rtp_enabled_worlds", List.of(World.OVERWORLD.getValue().getPath()), arrayParser(Object::toString));
     @ConfigOption public final Option<Boolean> BROADCAST_TO_OPS =       new Option<>("broadcast_to_ops", false, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> NICK_REVEAL_ON_HOVER =   new Option<>("nick_reveal_on_hover", true, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> GRANT_LOWEST_NUMERIC_BY_DEFAULT = new Option<>("grant_lowest_numeric_by_default", true, Boolean::parseBoolean);
@@ -102,6 +111,50 @@ public final class EssentialCommandsConfig extends Config<EssentialCommandsConfi
         NICKNAMES_IN_PLAYER_LIST.changeEvent.register(ign -> {
             PlayerDataManager.getInstance().queueNicknameUpdatesForAllPlayers();
         });
+
+
+        RTP_ENABLED_WORLDS.changeEvent.register(configuredWorldIdStrings -> {
+            ManagerLocator.getInstance().runAndQueue("RTP_ENABLED_WORLDS", server -> {
+                var worldIds = server.getWorldRegistryKeys().stream()
+                    .map(RegistryKey::getValue)
+                    .collect(Collectors.toSet());
+
+                EssentialCommands.LOGGER.info("Possible world ids: {}", String.join(",", worldIds.stream().map(Identifier::toString).toList()));
+
+                var configuredWorldIds = configuredWorldIdStrings.stream()
+                    .map(Identifier::new)
+                    .toList();
+                EssentialCommands.LOGGER.info("Configured `rtp_enabled_worlds` world ids: {}", String.join(",", configuredWorldIds.stream().map(Identifier::toString).toList()));
+
+                var validConfiguredWorldIds = configuredWorldIdStrings.stream()
+                    .map(Identifier::new)
+                    .filter(worldIds::contains)
+                    .collect(Collectors.toSet());
+
+                var invalidConfiguredWorldIds = configuredWorldIdStrings.stream()
+                    .map(Identifier::new)
+                    .filter(v -> !worldIds.contains(v))
+                    .toList();
+
+                if (invalidConfiguredWorldIds.size() > 0) {
+                    EssentialCommands.LOGGER.error("{} configured `rtp_enabled_worlds` world ids were invalid: {}", invalidConfiguredWorldIds.size(), String.join(",", invalidConfiguredWorldIds.stream().map(Identifier::toString).toList()));
+                } else {
+                    EssentialCommands.LOGGER.info("All configured `rtp_enabled_worlds` world ids are valid.");
+                }
+
+                this.validRtpWorldIds.clear();
+                server.getWorldRegistryKeys().stream()
+                    .filter(k -> validConfiguredWorldIds.contains(k.getValue()))
+                    .forEach(this.validRtpWorldIds::add);
+                EssentialCommands.refreshConfigSnapshot();
+            });
+        });
+    }
+
+    private final HashSet<RegistryKey<World>> validRtpWorldIds = new HashSet<>();
+    @NotNull
+    public Set<RegistryKey<World>> getValidRtpWorldKeys() {
+        return this.validRtpWorldIds;
     }
 
     public static <T> T getValueSafe(@NotNull Option<T> option, T defaultValue) {

--- a/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfigSnapshot.java
+++ b/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfigSnapshot.java
@@ -1,11 +1,14 @@
 package com.fibermc.essentialcommands.config;
 
 import java.util.List;
+import java.util.Set;
 
 import com.fibermc.essentialcommands.types.RespawnCondition;
 
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
+import net.minecraft.world.World;
 
 import dev.jpcode.eccore.config.expression.Expression;
 import dev.jpcode.eccore.util.TimeUtil;
@@ -57,6 +60,7 @@ public final class EssentialCommandsConfigSnapshot {
     public final int RTP_MIN_RADIUS;
     public final int RTP_COOLDOWN;
     public final int RTP_MAX_ATTEMPTS;
+    public final Set<RegistryKey<World>> RTP_ENABLED_WORLDS;
     public final boolean BROADCAST_TO_OPS;
     public final boolean NICK_REVEAL_ON_HOVER;
     public final boolean GRANT_LOWEST_NUMERIC_BY_DEFAULT;
@@ -117,6 +121,7 @@ public final class EssentialCommandsConfigSnapshot {
         this.RTP_MIN_RADIUS                     = config.RTP_MIN_RADIUS.getValue();
         this.RTP_COOLDOWN                       = config.RTP_COOLDOWN.getValue();
         this.RTP_MAX_ATTEMPTS                   = config.RTP_MAX_ATTEMPTS.getValue();
+        this.RTP_ENABLED_WORLDS                 = config.getValidRtpWorldKeys();
         this.BROADCAST_TO_OPS                   = config.BROADCAST_TO_OPS.getValue();
         this.NICK_REVEAL_ON_HOVER               = config.NICK_REVEAL_ON_HOVER.getValue();
         this.GRANT_LOWEST_NUMERIC_BY_DEFAULT    = config.GRANT_LOWEST_NUMERIC_BY_DEFAULT.getValue();

--- a/src/main/java/com/fibermc/essentialcommands/types/MinecraftLocation.java
+++ b/src/main/java/com/fibermc/essentialcommands/types/MinecraftLocation.java
@@ -38,6 +38,13 @@ public class MinecraftLocation {
         this.pitch = pitch;
     }
 
+    public MinecraftLocation(RegistryKey<World> dim, Vec3i vec3i, float headYaw, float pitch) {
+        this.dim = dim;
+        this.pos = Vec3d.ofCenter(vec3i);
+        this.headYaw = headYaw;
+        this.pitch = pitch;
+    }
+
     public MinecraftLocation(ServerPlayerEntity player) {
         this.dim = player.getWorld().getRegistryKey();
         this.pos = Vec3d.ZERO.add(player.getPos());

--- a/src/main/resources/assets/essential_commands/lang/en_us.json
+++ b/src/main/resources/assets/essential_commands/lang/en_us.json
@@ -22,7 +22,7 @@
   "cmd.nickname.set.error.perms": "Player has insufficient permissions for specified nickname.",
   "cmd.nickname.set.error.length": "Length of supplied nickname (${0}) exceeded max nickname length (${1})",
   "cmd.rtp.error.pre": "Could not execute command '/rtp'. Reason: ",
-  "cmd.rtp.error.not_overworld": "Not in Overworld.",
+  "cmd.rtp.error.world_not_enabled": "RTP is not enabled in the world '${0}'",
   "cmd.rtp.error.cooldown": "Command is on cooldown. (${0} seconds remaining.)",
   "cmd.rtp.error.no_spawn_set": "Spawn not set. (RTP chooses a random location a preset distance from spawn.)",
   "cmd.rtp.location_name": "random location",


### PR DESCRIPTION
feat: RTP enhancements (make it work in the Nether!) (and more!)


new config option:

- `rtp_enabled_worlds` - a list of world registry keys to allow `/rtp` in
  - Example: `rtp_enabled_worlds=[overworld,nether]`
  - This config option _can_ be reloaded with `/essentialcommands config reload`

new permission:

- `essentialcommands.bypass.randomteleport_cooldown`, defaultRequireLevel=4

lang file change:

- `cmd.rtp.error.no_spawn_set` -> `cmd.rtp.error.world_not_enabled`
  - Old `en_us` text: "Not in Overworld."
  - New `en_us` text: "RTP is not enabled in the world '${0}'" 

