### PR TITLE
fix: warp suggestions not perms filtered

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
+++ b/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
@@ -514,8 +514,8 @@ public final class EssentialCommandRegistry {
                 .requires(ECPerms.require(ECPerms.Registry.config_reload, 4))
                 .executes((context) -> {
                     BACKING_CONFIG.loadOrCreateProperties();
-                    context.getSource().sendFeedback(() ->
-                        BACKING_CONFIG.stateAsText(),
+                    context.getSource().sendFeedback(
+                        BACKING_CONFIG::stateAsText,
                         false
                     );
                     return 1;
@@ -524,10 +524,9 @@ public final class EssentialCommandRegistry {
                     .suggests(ListSuggestion.of(BACKING_CONFIG::getPublicFieldNames))
                     .executes(context -> {
                         try {
-                            Text t =  BACKING_CONFIG.getFieldValueAsText(
-                                    StringArgumentType.getString(context, "config_property"));
-                            context.getSource().sendFeedback(() -> t
-                            , false);
+                            Text t = BACKING_CONFIG.getFieldValueAsText(
+                                StringArgumentType.getString(context, "config_property"));
+                            context.getSource().sendFeedback(() -> t, false);
                         } catch (NoSuchFieldException e) {
                             e.printStackTrace();
                         }

--- a/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
+++ b/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
@@ -14,6 +14,7 @@ import com.fibermc.essentialcommands.commands.suggestions.TeleportResponseSugges
 import com.fibermc.essentialcommands.commands.suggestions.WarpSuggestion;
 import com.fibermc.essentialcommands.playerdata.PlayerData;
 import com.fibermc.essentialcommands.text.ECText;
+import com.fibermc.essentialcommands.types.NamedMinecraftLocation;
 import com.fibermc.essentialcommands.util.EssentialsConvertor;
 import com.fibermc.essentialcommands.util.EssentialsXParser;
 import org.apache.logging.log4j.Level;
@@ -242,7 +243,8 @@ public final class EssentialCommandRegistry {
                 .executes(ListCommandFactory.create(
                     ECText.getInstance().getString("cmd.warp.list.start"),
                     "warp tp",
-                    (context) -> ManagerLocator.getInstance().getWorldDataManager().getWarpEntries()
+                    (context) -> ManagerLocator.getInstance().getWorldDataManager().getAccessibleWarps(context.getSource().getPlayerOrThrow()).toList(),
+                    NamedMinecraftLocation::getName
                 ));
 
             LiteralCommandNode<ServerCommandSource> warpNode = warpBuilder
@@ -500,7 +502,7 @@ public final class EssentialCommandRegistry {
                     BACKING_CONFIG.loadOrCreateProperties();
                     var player = context.getSource().getPlayer();
                     var ecText = player != null ? ECText.access(player) : ECText.getInstance();
-                    context.getSource().sendFeedback(() -> 
+                    context.getSource().sendFeedback(() ->
                         ecText.getText("cmd.config.reload"),
                         true
                     );
@@ -512,7 +514,7 @@ public final class EssentialCommandRegistry {
                 .requires(ECPerms.require(ECPerms.Registry.config_reload, 4))
                 .executes((context) -> {
                     BACKING_CONFIG.loadOrCreateProperties();
-                    context.getSource().sendFeedback(() -> 
+                    context.getSource().sendFeedback(() ->
                         BACKING_CONFIG.stateAsText(),
                         false
                     );

--- a/src/main/java/com/fibermc/essentialcommands/WorldDataManager.java
+++ b/src/main/java/com/fibermc/essentialcommands/WorldDataManager.java
@@ -9,6 +9,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import com.fibermc.essentialcommands.types.MinecraftLocation;
 import com.fibermc.essentialcommands.types.WarpLocation;
@@ -21,6 +22,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.WorldSavePath;
 import net.minecraft.world.PersistentState;
 
@@ -144,6 +146,13 @@ public class WorldDataManager extends PersistentState {
 
     public List<String> getWarpNames() {
         return this.warps.keySet().stream().toList();
+    }
+
+    public Stream<WarpLocation> getAccessibleWarps(ServerPlayerEntity player) {
+        var warpsStream = this.warps.values().stream();
+        return (EssentialCommands.CONFIG.USE_PERMISSIONS_API
+            ? warpsStream.filter(loc -> loc.hasPermission(player))
+            : warpsStream);
     }
 
     public Set<Entry<String, WarpLocation>> getWarpEntries() {

--- a/src/main/java/com/fibermc/essentialcommands/commands/HomeTeleportOtherCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/HomeTeleportOtherCommand.java
@@ -3,6 +3,7 @@ package com.fibermc.essentialcommands.commands;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import com.fibermc.essentialcommands.ManagerLocator;
@@ -96,6 +97,7 @@ public class HomeTeleportOtherCommand extends HomeCommand implements Command<Ser
                     ECText.getInstance().getString("cmd.home.list.start"),
                     "home tp_offline %s".formatted(targetPlayerName),
                     targetPlayerData.getHomeEntries(),
+                    Entry::getKey,
                     senderPlayerProfile
                 );
 

--- a/src/main/java/com/fibermc/essentialcommands/commands/suggestions/WarpSuggestion.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/suggestions/WarpSuggestion.java
@@ -1,6 +1,7 @@
 package com.fibermc.essentialcommands.commands.suggestions;
 
 import com.fibermc.essentialcommands.ManagerLocator;
+import com.fibermc.essentialcommands.types.WarpLocation;
 
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 
@@ -11,6 +12,12 @@ public final class WarpSuggestion {
 
     //Brigader Suggestions
     public static final SuggestionProvider<ServerCommandSource> STRING_SUGGESTIONS_PROVIDER
-        = ListSuggestion.of(() -> ManagerLocator.getInstance().getWorldDataManager().getWarpNames());
+        = ListSuggestion.ofContext(
+            (ctx) -> ManagerLocator.getInstance()
+                .getWorldDataManager()
+                .getAccessibleWarps(ctx.getSource().getPlayerOrThrow())
+                .map(WarpLocation::getName)
+                .toList()
+        );
 
 }


### PR DESCRIPTION
Previously, all players could see all warps, regardless of if those warps were permissions-gated.