### PR TITLE
Port to 1.21-pre4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ archives_base_name = essential_commands
 # Dependencies
 permissions_api_version=0.3.1
 placeholder_api_version=2.4.0-pre.2+1.21
-pal_version=1.9.0
+pal_version=1.10.0
 vanish_version=1.5.3+1.20.4
 
 jetbrains_annotations_version = 22.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx2048M
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develup
-minecraft_version=1.20.5
-yarn_mappings=1.20.5+build.1
-loader_version=0.15.10
+minecraft_version=1.21-pre4
+yarn_mappings=1.21-pre4+build.3
+loader_version=0.15.11
 
 #Fabric api
-fabric_version=0.97.5+1.20.5
+fabric_version=0.100.0+1.21
 
 # Mod Properties
 mod_name = Essential Commands
@@ -20,7 +20,7 @@ archives_base_name = essential_commands
 
 # Dependencies
 permissions_api_version=0.3.1
-placeholder_api_version=2.4.0-pre.1+1.20.5
+placeholder_api_version=2.4.0-pre.2+1.21
 pal_version=1.9.0
 vanish_version=1.5.3+1.20.4
 

--- a/src/main/java/com/fibermc/essentialcommands/ECPlaceholderRegistry.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECPlaceholderRegistry.java
@@ -12,7 +12,7 @@ final class ECPlaceholderRegistry {
     public static void register() {
         var namespace = EssentialCommands.MOD_ID;
         Placeholders.register(
-            new Identifier(namespace, "nickname"),
+            Identifier.of(namespace, "nickname"),
             (ctx, arg) -> {
                 if (ctx.hasPlayer()) {
                     return PlaceholderResult.value(

--- a/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
+++ b/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
@@ -631,7 +631,7 @@ public final class EssentialCommandRegistry {
             essentialCommandsRootNode.addChild(CommandManager.literal("convertEssentialsXPlayerHomes")
                 .requires(source -> source.hasPermissionLevel(4))
                 .executes((source) -> {
-                    Path mcDir = source.getSource().getServer().getRunDirectory().toPath();
+                    Path mcDir = source.getSource().getServer().getRunDirectory();
                     try {
                         EssentialsXParser.convertPlayerDataDir(
                             mcDir.resolve("plugins/Essentials/userdata").toFile(),
@@ -648,7 +648,7 @@ public final class EssentialCommandRegistry {
             essentialCommandsRootNode.addChild(CommandManager.literal("convertEssentialsXWarps")
                 .requires(source -> source.hasPermissionLevel(4))
                 .executes((source) -> {
-                    Path mcDir = source.getSource().getServer().getRunDirectory().toPath();
+                    Path mcDir = source.getSource().getServer().getRunDirectory();
                     EssentialsConvertor.warpConvert(
                         source.getSource().getServer(),
                         mcDir.resolve("plugins/Essentials/warps").toFile()

--- a/src/main/java/com/fibermc/essentialcommands/commands/RulesCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RulesCommand.java
@@ -42,7 +42,7 @@ public final class RulesCommand {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public static void reload(MinecraftServer server) throws IOException {
-        Path mcDir = server.getRunDirectory().toPath();
+        Path mcDir = server.getRunDirectory();
         var rulesFile = mcDir.resolve("config/essentialcommands/rules.txt").toFile();
         rulesFile.getParentFile().mkdirs();
         if (rulesFile.createNewFile()) {

--- a/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
+++ b/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
@@ -136,17 +136,17 @@ public final class EssentialCommandsConfig extends Config<EssentialCommandsConfi
                 EssentialCommands.LOGGER.info("Possible world ids: {}", String.join(",", worldIds.stream().map(Identifier::toString).toList()));
 
                 var configuredWorldIds = configuredWorldIdStrings.stream()
-                    .map(Identifier::new)
+                    .map(Identifier::of)
                     .toList();
                 EssentialCommands.LOGGER.info("Configured `rtp_enabled_worlds` world ids: {}", String.join(",", configuredWorldIds.stream().map(Identifier::toString).toList()));
 
                 var validConfiguredWorldIds = configuredWorldIdStrings.stream()
-                    .map(Identifier::new)
+                    .map(Identifier::of)
                     .filter(worldIds::contains)
                     .collect(Collectors.toSet());
 
                 var invalidConfiguredWorldIds = configuredWorldIdStrings.stream()
-                    .map(Identifier::new)
+                    .map(Identifier::of)
                     .filter(v -> !worldIds.contains(v))
                     .toList();
 

--- a/src/main/java/com/fibermc/essentialcommands/mixin/PlayerManagerMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/PlayerManagerMixin.java
@@ -1,7 +1,5 @@
 package com.fibermc.essentialcommands.mixin;
 
-import java.util.Optional;
-
 import com.fibermc.essentialcommands.ECAbilitySources;
 import com.fibermc.essentialcommands.events.PlayerConnectCallback;
 import com.fibermc.essentialcommands.events.PlayerLeaveCallback;
@@ -16,12 +14,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ConnectedClientData;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.TeleportTarget;
 
 @Mixin(PlayerManager.class)
 public abstract class PlayerManagerMixin {
@@ -55,13 +54,10 @@ public abstract class PlayerManagerMixin {
         target = "Lnet/minecraft/server/network/ServerPlayerEntity;copyFrom(Lnet/minecraft/server/network/ServerPlayerEntity;Z)V"
     ), locals = LocalCapture.CAPTURE_FAILHARD)
     public void onRespawnPlayer(
-        ServerPlayerEntity oldServerPlayerEntity, boolean alive, CallbackInfoReturnable<ServerPlayerEntity> cir
-        , BlockPos blockPos
-        , float f
-        , boolean bl
+        ServerPlayerEntity oldServerPlayerEntity, boolean alive, Entity.RemovalReason removalReason
+        , CallbackInfoReturnable<ServerPlayerEntity> cir
+        , TeleportTarget teleportTarget
         , ServerWorld serverWorld
-        , Optional optional
-        , ServerWorld serverWorld2
         , ServerPlayerEntity serverPlayerEntity
     ) {
         PlayerDataManager.handlePlayerDataRespawnSync(oldServerPlayerEntity, serverPlayerEntity);
@@ -74,14 +70,13 @@ public abstract class PlayerManagerMixin {
         target = "Lnet/minecraft/server/world/ServerWorld;getLevelProperties()Lnet/minecraft/world/WorldProperties;"
     ), locals = LocalCapture.CAPTURE_FAILHARD)
     public void onRespawnPlayer_afterSetPosition(
-        ServerPlayerEntity oldServerPlayerEntity, boolean alive, CallbackInfoReturnable<ServerPlayerEntity> cir
-        , BlockPos blockPos
-        , float f
-        , boolean bl
+        ServerPlayerEntity oldServerPlayerEntity, boolean alive, Entity.RemovalReason removalReason
+        , CallbackInfoReturnable<ServerPlayerEntity> cir
+        , TeleportTarget teleportTarget
         , ServerWorld serverWorld
-        , Optional optional
-        , ServerWorld serverWorld2
         , ServerPlayerEntity serverPlayerEntity
+        , byte b
+        , ServerWorld serverWorld2
     ) {
         PlayerDataManager.handleRespawnAtEcSpawn(oldServerPlayerEntity, serverPlayerEntity);
         PlayerRespawnCallback.EVENT.invoker().onPlayerRespawn(oldServerPlayerEntity, serverPlayerEntity);

--- a/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
@@ -18,12 +18,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.world.GameMode;
+import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProperties;
 
@@ -60,14 +63,18 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntityMixin implemen
 //        ((ServerPlayerEntityAccess) this).getEcPlayerData().updatePlayer(((ServerPlayerEntity) (Object) this));
     }
 
-    @Inject(method = "teleport(Lnet/minecraft/server/world/ServerWorld;DDDFF)V", at = @At(
+    @Inject(method = "teleportTo(Lnet/minecraft/world/TeleportTarget;)Lnet/minecraft/entity/Entity;", at = @At(
         value = "INVOKE",
         target = "Lnet/minecraft/server/PlayerManager;sendPlayerStatus(Lnet/minecraft/server/network/ServerPlayerEntity;)V"
     ), locals = LocalCapture.CAPTURE_FAILSOFT)
     public void onTeleportBetweenWorlds(
-        ServerWorld targetWorld, double x, double y, double z, float yaw, float pitch,
-        CallbackInfo ci,
-        ServerWorld serverWorld, WorldProperties worldProperties)
+        TeleportTarget teleportTarget,
+        CallbackInfoReturnable<Entity> cir,
+        ServerWorld serverWorld,
+        ServerWorld serverWorld2,
+        RegistryKey<World> registryKey,
+        WorldProperties worldProperties,
+        PlayerManager playerManager)
     {
         var playerData = ((ServerPlayerEntityAccess) this).ec$getPlayerData();
         playerData.updatePlayerEntity((ServerPlayerEntity) (Object) this);

--- a/src/main/java/com/fibermc/essentialcommands/mixin/WorldSaveHandlerMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/WorldSaveHandlerMixin.java
@@ -9,9 +9,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.world.WorldSaveHandler;
+import net.minecraft.world.PlayerSaveHandler;
 
-@Mixin(WorldSaveHandler.class)
+@Mixin(PlayerSaveHandler.class)
 public class WorldSaveHandlerMixin {
 
     @Inject(method = "savePlayerData", at = @At("RETURN"))

--- a/src/main/java/com/fibermc/essentialcommands/util/NicknameTextUtil.java
+++ b/src/main/java/com/fibermc/essentialcommands/util/NicknameTextUtil.java
@@ -42,7 +42,7 @@ public final class NicknameTextUtil {
                     || style.isObfuscated()
                     || style.isStrikethrough()
                     || style.isUnderlined())
-                || !style.getFont().equals(new Identifier("minecraft:default"))),
+                || !style.getFont().equals(Identifier.of("minecraft:default"))),
             (sourcePerms.click || (style.getClickEvent() == null)),
             (sourcePerms.hover || (style.getHoverEvent() == null))
         );


### PR DESCRIPTION
This PR contains the changes we needed to make EC work on 1.21-pre4 for our testing server. Maybe they can be of use as a starting point?

Update dependencies to 1.21-pre4. Note that PlayerAbilityLib requires a not yet accepted PR
(https://github.com/Ladysnake/PlayerAbilityLib/pull/24). This was tested using a local build of pal.

Adapt to new function signatures for mixins.