### PR TITLE
fix keeping flight ability after respawn

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,19 +32,19 @@ jobs:
 
     steps:
       - name: ✨ Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 🛂 Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: 🏗 Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: adopt
 
       - name: 📷 Begin Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -59,14 +59,14 @@ jobs:
         run: gradle clean build
 
       - name: 📦 Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: '**/build/libs/'
 
       - name: 📝 Upload reports
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: '**/build/reports/'

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
@@ -404,10 +404,9 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
 
     @Override
     public void updatePlayerEntity(ServerPlayerEntity serverPlayerEntity) {
+        boolean couldFly = VanillaAbilities.ALLOW_FLYING.getTracker(this.player).isGrantedBy(ECAbilitySources.FLY_COMMAND);
         this.player = serverPlayerEntity;
-
-        // This is to fix a bug with ability to fly being lost upon being teleported to a new dim via /execute...tp.
-        PlayerDataManager.getInstance().scheduleTask(this::updateFlight);
+        setFlight(couldFly);
     }
 
     private void updateFlight() {
@@ -428,7 +427,9 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
         } else {
             Pal.revokeAbility(this.player, VanillaAbilities.ALLOW_FLYING, ECAbilitySources.FLY_COMMAND);
         }
-        this.player.sendAbilitiesUpdate();
+
+        // This is to fix a bug with ability to fly being lost upon being teleported to a new dim via /execute...tp.
+        PlayerDataManager.getInstance().scheduleTask(this::updateFlight);
     }
 
     public void clearAbilitiesWithoutPermisisons() {


### PR DESCRIPTION
after some digging I found that flySpeed was kept, but mayFly got reset(to false) 
this made me suspect PAL having an opinion in the matter 
getting PAL flight status from the old player and applying it after updating the player seems to do the trick