### PR TITLE
feat: add `/sleep` command

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/ECAbilitySources.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECAbilitySources.java
@@ -17,4 +17,5 @@ public final class ECAbilitySources {
     public static final AbilitySource FLY_COMMAND = Pal.getAbilitySource(EssentialCommands.MOD_ID, "ec-fly-command");
     public static final AbilitySource INVULN_COMMAND = Pal.getAbilitySource(EssentialCommands.MOD_ID, "ec-invuln-command");
     public static final AbilitySource AFK_INVULN = Pal.getAbilitySource(EssentialCommands.MOD_ID, "ec-afk-invuln");
+    public static final AbilitySource SLEEP_INVULN = Pal.getAbilitySource(EssentialCommands.MOD_ID, "ec-sleep-invuln");
 }

--- a/src/main/java/com/fibermc/essentialcommands/ECPerms.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECPerms.java
@@ -62,6 +62,7 @@ public final class ECPerms {
         public static final String time_set_day = "essentialcommands.day";
         public static final String afk = "essentialcommands.afk";
         public static final String bed = "essentialcommands.bed";
+        public static final String sleep = "essentialcommands.sleep";
         public static final String config_reload = "essentialcommands.config.reload";
         public static final String bypass_teleport_delay = "essentialcommands.bypass.teleport_delay";
         public static final String bypass_allow_teleport_between_dimensions = "essentialcommands.bypass.allow_teleport_between_dimensions";

--- a/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
+++ b/src/main/java/com/fibermc/essentialcommands/EssentialCommandRegistry.java
@@ -459,6 +459,13 @@ public final class EssentialCommandRegistry {
                 .build());
         }
 
+        if (CONFIG.ENABLE_SLEEP) {
+            registerNode.accept(CommandManager.literal("sleep")
+                .requires(ECPerms.require(ECPerms.Registry.sleep, 0))
+                .executes(new SleepCommand())
+                .build());
+        }
+
         registerNode.accept(CommandManager.literal("lastPos")
             .requires(ECPerms.require("essentialcommands.admin.lastpos", 2))
                 .then(argument("target_player", StringArgumentType.word())

--- a/src/main/java/com/fibermc/essentialcommands/commands/SleepCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/SleepCommand.java
@@ -1,0 +1,44 @@
+package com.fibermc.essentialcommands.commands;
+
+import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
+import com.fibermc.essentialcommands.playerdata.PlayerData;
+import com.fibermc.essentialcommands.util.PlayerUtilities;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import net.minecraft.server.command.ServerCommandSource;
+
+import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
+
+public class SleepCommand implements Command<ServerCommandSource> {
+    @Override
+    public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        var source = context.getSource();
+        var player = source.getPlayerOrThrow();
+        var playerAccess = (ServerPlayerEntityAccess)player;
+        var playerData = PlayerData.access(player);
+        var pos = player.getBlockPos();
+
+        if (player.isSleeping()) {
+            player.wakeUp();
+            return SINGLE_SUCCESS;
+        }
+
+        if (!CONFIG.SLEEP_NEAR_MONSTERS && PlayerUtilities.isNearAngryMonsters(player)) {
+            // todo: use mc text?
+            PlayerData.access(player).sendError("cmd.sleep.error.near_monsters");
+            return 0;
+        }
+
+        if (CONFIG.SLEEP_INVULN) {
+            // todo: set invuln ability
+        }
+
+        player.sleep(pos);
+        playerData.setIsSleepingFromCommand(true);
+
+        return SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/com/fibermc/essentialcommands/commands/SleepCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/SleepCommand.java
@@ -1,6 +1,5 @@
 package com.fibermc.essentialcommands.commands;
 
-import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
 import com.fibermc.essentialcommands.playerdata.PlayerData;
 import com.fibermc.essentialcommands.util.PlayerUtilities;
 
@@ -9,6 +8,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
 
 import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 
@@ -17,7 +17,6 @@ public class SleepCommand implements Command<ServerCommandSource> {
     public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         var source = context.getSource();
         var player = source.getPlayerOrThrow();
-        var playerAccess = (ServerPlayerEntityAccess)player;
         var playerData = PlayerData.access(player);
         var pos = player.getBlockPos();
 
@@ -27,8 +26,7 @@ public class SleepCommand implements Command<ServerCommandSource> {
         }
 
         if (!CONFIG.SLEEP_NEAR_MONSTERS && PlayerUtilities.isNearAngryMonsters(player)) {
-            // todo: use mc text?
-            PlayerData.access(player).sendError("cmd.sleep.error.near_monsters");
+            PlayerData.access(player).sendCommandError(Text.translatable("block.minecraft.bed.not_safe"));
             return 0;
         }
 

--- a/src/main/java/com/fibermc/essentialcommands/commands/SleepCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/SleepCommand.java
@@ -32,10 +32,6 @@ public class SleepCommand implements Command<ServerCommandSource> {
             return 0;
         }
 
-        if (CONFIG.SLEEP_INVULN) {
-            // todo: set invuln ability
-        }
-
         player.sleep(pos);
         playerData.setIsSleepingFromCommand(true);
 

--- a/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
+++ b/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfig.java
@@ -70,6 +70,7 @@ public final class EssentialCommandsConfig extends Config<EssentialCommandsConfi
     @ConfigOption public final Option<Boolean> ENABLE_NIGHT =           new Option<>("enable_night", true, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> ENABLE_REPAIR =          new Option<>("enable_repair", true, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> ENABLE_NEAR =            new Option<>("enable_near", true, Boolean::parseBoolean);
+    @ConfigOption public final Option<Boolean> ENABLE_SLEEP =           new Option<>("enable_sleep", false, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> ENABLE_DELETE_ALL_PLAYER_DATA = new Option<>("enable_delete_all_player_data", true, Boolean::parseBoolean);
     @ConfigOption public final Option<List<Integer>> HOME_LIMIT =       new Option<>("home_limit", List.of(1, 2, 5), arrayParser(ConfigUtil::parseInt));
     @ConfigOption public final Option<Double>  TELEPORT_COOLDOWN =      new Option<>("teleport_cooldown", 1.0, ConfigUtil::parseDouble);
@@ -102,6 +103,8 @@ public final class EssentialCommandsConfig extends Config<EssentialCommandsConfi
     @ConfigOption public final Option<Boolean> INVULN_WHILE_AFK = new Option<>("invuln_while_afk", false, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> AUTO_AFK_ENABLED = new Option<>("auto_afk_enabled", true,  Boolean::parseBoolean);
     @ConfigOption public final Option<Integer> AUTO_AFK_TICKS = new Option<>("auto_afk_time", durationToTicks(Duration.ofMinutes(15)), ConfigUtil::parseDurationToTicks, ConfigUtil::serializeTicksAsDuration);
+    @ConfigOption public final Option<Boolean> SLEEP_NEAR_MONSTERS = new Option<>("sleep_near_monsters", false, Boolean::parseBoolean);
+    @ConfigOption public final Option<Boolean> SLEEP_INVULN = new Option<>("sleep_invuln", false, Boolean::parseBoolean);
     @ConfigOption public final Option<Boolean> REGISTER_TOP_LEVEL_COMMANDS = new Option<>("register_top_level_commands", true, Boolean::parseBoolean);
     @ConfigOption public final Option<List<String>> EXCLUDED_TOP_LEVEL_COMMANDS = new Option<>("excluded_top_level_commands", List.of(), ConfigUtil.arrayParser(Object::toString));
     @ConfigOption public final Option<Expression<RespawnCondition>> RESPAWN_AT_EC_SPAWN = new Option<>("respawn_at_ec_spawn", Expression.of(RespawnCondition.Never), (str) -> str.isBlank() ? Expression.of(RespawnCondition.Never) : PatternMatchingExpressionReader.parse(str, RespawnCondition::valueOf), Expression::serialize);

--- a/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfigSnapshot.java
+++ b/src/main/java/com/fibermc/essentialcommands/config/EssentialCommandsConfigSnapshot.java
@@ -48,6 +48,7 @@ public final class EssentialCommandsConfigSnapshot {
     public final boolean ENABLE_NIGHT;
     public final boolean ENABLE_REPAIR;
     public final boolean ENABLE_NEAR;
+    public final boolean ENABLE_SLEEP;
     public final boolean ENABLE_DELETE_ALL_PLAYER_DATA;
     public final List<Integer> HOME_LIMIT;
     public final double TELEPORT_COOLDOWN;
@@ -80,6 +81,8 @@ public final class EssentialCommandsConfigSnapshot {
     public final boolean INVULN_WHILE_AFK;
     public final boolean AUTO_AFK_ENABLED;
     public final int AUTO_AFK_TICKS;
+    public final boolean SLEEP_NEAR_MONSTERS;
+    public final boolean SLEEP_INVULN;
     public final boolean REGISTER_TOP_LEVEL_COMMANDS;
     public final List<String> EXCLUDED_TOP_LEVEL_COMMANDS;
     public final Expression<RespawnCondition> RESPAWN_AT_EC_SPAWN;
@@ -123,6 +126,7 @@ public final class EssentialCommandsConfigSnapshot {
         this.ENABLE_NIGHT                       = config.ENABLE_NIGHT.getValue();
         this.ENABLE_REPAIR                      = config.ENABLE_REPAIR.getValue();
         this.ENABLE_NEAR                        = config.ENABLE_NEAR.getValue();
+        this.ENABLE_SLEEP                       = config.ENABLE_SLEEP.getValue();
         this.ENABLE_DELETE_ALL_PLAYER_DATA      = config.ENABLE_DELETE_ALL_PLAYER_DATA.getValue();
         this.HOME_LIMIT                         = config.HOME_LIMIT.getValue();
         this.TELEPORT_COOLDOWN                  = config.TELEPORT_COOLDOWN.getValue();
@@ -155,6 +159,8 @@ public final class EssentialCommandsConfigSnapshot {
         this.INVULN_WHILE_AFK                   = config.INVULN_WHILE_AFK.getValue();
         this.AUTO_AFK_ENABLED                   = config.AUTO_AFK_ENABLED.getValue();
         this.AUTO_AFK_TICKS                     = config.AUTO_AFK_TICKS.getValue();
+        this.SLEEP_NEAR_MONSTERS                = config.SLEEP_NEAR_MONSTERS.getValue();
+        this.SLEEP_INVULN                       = config.SLEEP_INVULN.getValue();
         this.REGISTER_TOP_LEVEL_COMMANDS        = config.REGISTER_TOP_LEVEL_COMMANDS.getValue();
         this.EXCLUDED_TOP_LEVEL_COMMANDS        = config.EXCLUDED_TOP_LEVEL_COMMANDS.getValue();
         this.RESPAWN_AT_EC_SPAWN                = config.RESPAWN_AT_EC_SPAWN.getValue();

--- a/src/main/java/com/fibermc/essentialcommands/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/LivingEntityMixin.java
@@ -1,0 +1,41 @@
+package com.fibermc.essentialcommands.mixin;
+
+import com.fibermc.essentialcommands.playerdata.PlayerData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+@Mixin(LivingEntity.class)
+public class LivingEntityMixin {
+    @Inject(method = "isSleepingInBed", at = @At("RETURN"), cancellable = true)
+    public void modifyIsSleepingInBedReturn(CallbackInfoReturnable<Boolean> cir) {
+        LivingEntity self = (LivingEntity)(Object)this;
+        if (!(self instanceof ServerPlayerEntity player)) {
+            return;
+        }
+
+        var playerData = PlayerData.access(player);
+        if (playerData.isSleepingFromCommand()) {
+            cir.setReturnValue(true);
+        }
+    }
+
+    @Inject(method = "wakeUp", at = @At("RETURN"))
+    public void modifyWakeUp(CallbackInfo ci) {
+        LivingEntity self = (LivingEntity)(Object)this;
+        if (!(self instanceof ServerPlayerEntity player)) {
+            return;
+        }
+
+        var playerData = PlayerData.access(player);
+        if (playerData.isSleepingFromCommand()) {
+            playerData.setIsSleepingFromCommand(false);
+        }
+    }
+}
+

--- a/src/main/java/com/fibermc/essentialcommands/mixin/PlayerEntityMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/PlayerEntityMixin.java
@@ -18,7 +18,7 @@ import net.minecraft.text.Text;
 import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 
 @Mixin(PlayerEntity.class)
-public abstract class PlayerEntityMixin {
+public abstract class PlayerEntityMixin extends LivingEntityMixin {
     @Inject(method = "getDisplayName", at = @At("RETURN"))
     public void onGetDisplayName(CallbackInfoReturnable<Text> cir) {
 

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
@@ -94,6 +94,8 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
             updateLastActionTick();
             setAfk(false);
         });
+        // this should never stick around between respawns
+        Pal.revokeAbility(player, VanillaAbilities.INVULNERABLE, ECAbilitySources.SLEEP_INVULN);
     }
 
     /**
@@ -318,6 +320,9 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
 
     public void setIsSleepingFromCommand(boolean sleepingFromCommand) {
         this.isSleepingFromCommand = sleepingFromCommand;
+        if (CONFIG.SLEEP_INVULN && sleepingFromCommand) {
+            Pal.grantAbility(player, VanillaAbilities.INVULNERABLE, ECAbilitySources.SLEEP_INVULN);
+        }
     }
 
     private static final class StorageKey {

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
@@ -80,6 +80,7 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
     private int lastActionTick;
     private int lastMovedTick;
     private boolean hasMovedThisTick;
+    private boolean isSleepingFromCommand;
 
     public PlayerData(ServerPlayerEntity player, File saveFile) {
         this.player = player;
@@ -309,6 +310,14 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
 
     public void updateLastActionTick() {
         this.lastActionTick = player.server.getTicks();
+    }
+
+    public boolean isSleepingFromCommand() {
+        return isSleepingFromCommand;
+    }
+
+    public void setIsSleepingFromCommand(boolean sleepingFromCommand) {
+        this.isSleepingFromCommand = sleepingFromCommand;
     }
 
     private static final class StorageKey {

--- a/src/main/java/com/fibermc/essentialcommands/util/PlayerUtilities.java
+++ b/src/main/java/com/fibermc/essentialcommands/util/PlayerUtilities.java
@@ -1,0 +1,35 @@
+package com.fibermc.essentialcommands.util;
+
+import java.util.List;
+
+import net.minecraft.entity.mob.HostileEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+
+public final class PlayerUtilities {
+    private PlayerUtilities() {}
+
+    public static boolean isNearAngryMonsters(ServerPlayerEntity player) {
+        var world = player.getServerWorld();
+        var pos = player.getBlockPos();
+        double boxHorizontalSize = 8.0;
+        double boxHeight = 5.0;
+        Vec3d vec3d = Vec3d.ofBottomCenter(pos);
+        List<HostileEntity> list = world
+            .getEntitiesByClass(
+                HostileEntity.class,
+                new Box(
+                    vec3d.getX() - boxHorizontalSize,
+                    vec3d.getY() - boxHeight,
+                    vec3d.getZ() - boxHorizontalSize,
+                    vec3d.getX() + boxHorizontalSize,
+                    vec3d.getY() + boxHeight,
+                    vec3d.getZ() + boxHorizontalSize
+                ),
+                (entity) -> entity.isAngryAt(world, player)
+            );
+
+        return !list.isEmpty();
+    }
+}

--- a/src/main/resources/essential_commands.mixins.json
+++ b/src/main/resources/essential_commands.mixins.json
@@ -3,6 +3,7 @@
   "package": "com.fibermc.essentialcommands.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "LivingEntityMixin",
     "PersistentStateManagerInvoker",
     "PlayerEntityMixin",
     "PlayerListS2CPacketActionMixin",


### PR DESCRIPTION
This command allows sleeping anywhere, even without a bed.

Permissions:

- `essentialcommands.sleep`

Config:

- `enable_sleep` (bool, default false)
  - if true, the sleep command will be registered, otherwise it will not be available (requires restart)
- `sleep_invuln` (bool, default false)
  - if true, players sleeping with this command will be invulnerable while sleeping
- `sleep_near_monsters` (bool, default false)
  - whether the command bypasses the vanilla "cannot rest near monsters" check