### PR TITLE
update permissions api and fix safe MOTD

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ maven_group = com.fibermc
 archives_base_name = essential_commands
 
 # Dependencies
-permissions_api_version=0.3.3
+permissions_api_version=0.4.0
 placeholder_api_version=2.6.2+1.21.5
 pal_version=1.14.0
 vanish_version=1.5.13+1.21.5

--- a/src/main/java/com/fibermc/essentialcommands/commands/MotdCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/MotdCommand.java
@@ -19,7 +19,7 @@ public final class MotdCommand {
 
     private static final NodeParser NODE_PARSER = ParserBuilder.of()
         .globalPlaceholders()
-        .add(TagParser.QUICK_TEXT_WITH_STF_SAFE)
+        .add(TagParser.QUICK_TEXT_WITH_STF)
         .build();
 
     public static int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {


### PR DESCRIPTION
couple fixes that probably shouldn't be in the same PR, but here we are
updated permissions api to 4.0 to fix a crash on 1.21.6 and above
and for the reason I got into the code this time, MOTD didn't allow unsafe tags, but they're fine here, can only be changed in config anyway