### PR TITLE
docs: make pages consistent with each other in what they describe

### DIFF
--- a/docs/Config-Documentation.md
+++ b/docs/Config-Documentation.md
@@ -75,7 +75,7 @@ The config file can be found at `config/EssentialCommands.properties`
 | rtp_cooldown                                           | 30                         | integer                      |
 | rtp_enabled_worlds                                     | overworld                  | world name (ex `the_nether`) |
 | rtp_max_attempts                                       | 15                         | integer                      |
-| rtp_min_radius                                         | `rtp_radius` (1000)        | integer (`<= rtp_radius`)    |
+| rtp_min_radius                                         | auto-matches `rtp_radius`  | integer (`<= rtp_radius`)    |
 | rtp_radius                                             | 1000                       | integer                      |
 | sleep_invuln                                           | false                      | boolean                      |
 | sleep_near_monsters                                    | false                      | boolean                      |

--- a/docs/Config-Documentation.md
+++ b/docs/Config-Documentation.md
@@ -11,7 +11,6 @@ The config file can be found at `config/EssentialCommands.properties`
 
 | Config Var                                             | Default Value              | Acceptable Values            |
 |--------------------------------------------------------|----------------------------|------------------------------|
-| ~~teleport_cooldown~~                                  | 1.0                        | double (seconds)             |
 | afk_prefix                                             | "[AFK] " (gray)            | MinecraftText                |
 | allow_back_on_death                                    | false                      | boolean                      |
 | allow_teleport_between_dimensions                      | true                       | boolean                      |
@@ -24,23 +23,33 @@ The config file can be found at `config/EssentialCommands.properties`
 | enable_back                                            | true                       | boolean                      |
 | enable_bed                                             | false                      | boolean                      |
 | enable_day                                             | true                       | boolean                      |
+| enable_delete_all_player_data                          | true                       | boolean                      |
 | enable_enderchest                                      | true                       | boolean                      |
 | enable_experimental_essentialsx_converter              | false                      | boolean                      |
+| enable_extinguish                                      | true                       | boolean                      |
+| enable_feed                                            | true                       | boolean                      |
 | enable_fly                                             | true                       | boolean                      |
 | enable_gametime                                        | true                       | boolean                      |
+| enable_heal                                            | true                       | boolean                      |
 | enable_home                                            | true                       | boolean                      |
 | enable_invuln                                          | true                       | boolean                      |
 | enable_motd                                            | false                      | boolean                      |
+| enable_near                                            | true                       | boolean                      |
 | enable_nick                                            | true                       | boolean                      |
 | enable_night                                           | true                       | boolean                      |
+| enable_repair                                          | true                       | boolean                      |
 | enable_rtp                                             | true                       | boolean                      |
+| enable_rules                                           | true                       | boolean                      |
 | enable_sleep                                           | false                      | boolean                      |
 | enable_spawn                                           | true                       | boolean                      |
+| enable_suicide                                         | true                       | boolean                      |
+| enable_top                                             | true                       | boolean                      |
 | enable_tpa                                             | true                       | boolean                      |
 | enable_warp                                            | true                       | boolean                      |
 | enable_wastebin                                        | true                       | boolean                      |
 | enable_workbench                                       | true                       | boolean                      |
 | excluded_top_level_commands                            | []                         | list of command names        |
+| fly_max_speed                                          | 5                          | integer                      |
 | formatting_accent                                      | light_purple               | Formatting Code, Style JSON  |
 | formatting_default                                     | gold                       | Formatting Code, Style JSON  |
 | formatting_error                                       | red                        | Formatting Code, Style JSON  |
@@ -49,6 +58,8 @@ The config file can be found at `config/EssentialCommands.properties`
 | invuln_while_afk                                       | false                      | boolean                      |
 | language                                               | en_us                      | (see language ids below)     |
 | motd                                                   | *A welcome message*        | String (Text)                |
+| near_command_default_radius                            | 200                        | integer                      |
+| near_command_max_radius                                | 200                        | integer                      |
 | nick_reveal_on_hover                                   | true                       | boolean                      |
 | nickname_above_head                                    | false                      | boolean                      |
 | nickname_max_length                                    | 32                         | integer                      |
@@ -56,6 +67,7 @@ The config file can be found at `config/EssentialCommands.properties`
 | nicknames_in_player_list                               | true                       | boolean                      |
 | ops_bypass_teleport_rules                              | true                       | boolean                      |
 | persist_back_location                                  | false                      | boolean                      |
+| print_teleport_coordinates                             | true                       | boolean                      |
 | recheck_player_ability_permissions_on_dimension_change | false                      | boolean                      |
 | register_top_level_commands                            | true                       | boolean                      |
 | respawn_at_ec_spawn                                    | Never                      | RespawnCondition Expression  |
@@ -67,9 +79,14 @@ The config file can be found at `config/EssentialCommands.properties`
 | rtp_radius                                             | 1000                       | integer                      |
 | sleep_invuln                                           | false                      | boolean                      |
 | sleep_near_monsters                                    | false                      | boolean                      |
+| ~~teleport_cooldown~~                                  | 1.0                        | double (seconds)             |
 | teleport_delay                                         | 0.0                        | double (seconds)             |
 | teleport_interrupt_on_damaged                          | true                       | boolean                      |
+| teleport_interrupt_on_move                             | false                      | boolean                      |
+| teleport_interrupt_on_move_max_blocks                  | 3.0                        | double (blocks)              |
 | teleport_request_duration                              | 60                         | integer (seconds)            |
+| teleport_with_followers                                | false                      | boolean                      |
+| teleport_with_followers_radius                         | 100.0                      | double (blocks)              |
 | use_permissions_api                                    | false                      | boolean                      |
 
 *Note: if `use_permissions_api` is set to true, OPs are treated as having all permissions (thus making the `ops_bypass_teleport_rules` config option do nothing).*
@@ -83,14 +100,14 @@ The config file can be found at `config/EssentialCommands.properties`
 ### Integer
 
 Positive or negative whole number. \
-Negative values generally disable their respecitve property.
+Negative values generally disable their respective property.
 
 Examples: `1`, `20`, `-3`
 
 ### Double
 
 Positive or negative floating point number (can have decimals). \
-Negative values generally disable their respecitve property.
+Negative values generally disable their respective property.
 
 Examples: `1.0`, `20.5`, `-3.125`
 
@@ -122,6 +139,7 @@ Valid values:
 - Always
 - NoBed
 - SameWorld
+- FirstJoin
 
 ### Expression
 
@@ -136,13 +154,37 @@ config value to do just that is `NoBed OR SameWorld`.
 In short, Expressions allow you to represent multiple conditions at once, joined
 by either `OR` or `AND`. Grouping with parentheses also works.
 
+## Numeric Permissions
+
+Several config options (like `home_limit`) use a tiered numeric permission
+system when `use_permissions_api=true`. These accept a comma-separated list of
+integers; each value generates a corresponding permission node (e.g.
+`essentialcommands.home.limit.5`).
+
+### `grant_lowest_numeric_by_default`
+
+When enabled (the default), players without any explicit tiered numeric
+permission are treated as having the *lowest* value in the list, rather than
+`0`. Setting this to `false` means a player with no such permission gets no
+access at all (for example, no homes).
+
+See [Home Limit](Home-Limit) for a more complete example.
+
 ## Languages
 
 List of supported language ids (use these in the "language" config option):
 
-- en_us
-- pt_br (Courtesy of AnonymozzY on CF)
-- ru_ru (Courtesy of @oldBrowze)
-- zh_cn (Courtesy of @MikhailTapio, @deluxghost, @Leo204_LKY)
+- de_de (German)
+- en_us (English, US)
+- es_es (Spanish, Spain)
+- fr_fr (French, France)
+- ko_kr (Korean)
+- nl_nl (Dutch)
+- pt_br (Portuguese, Brazil -- courtesy of AnonymozzY on CF)
+- ru_ru (Russian -- courtesy of @oldBrowze)
+- zh_cn (Chinese, Simplified -- courtesy of @MikhailTapio, @deluxghost, @Leo204_LKY)
+- zh_tw (Chinese, Traditional)
+
+See also the [Language](Language) page.
 
 [home-limit]: Home-Limit

--- a/docs/Feature-Guide.md
+++ b/docs/Feature-Guide.md
@@ -327,7 +327,7 @@ This admin command allows tracking a player's most recent position, even if they
 
 | Feature | Commands | Permissions |
 |---------|----------|------------|
-| Get player's last position | `/lastpos <player>` | `essentialcommands.admin.lasPos` |
+| Get player's last position | `/lastpos <player>` | `essentialcommands.admin.lastPos` |
 
 ### Clear Player Data
 This command is extremely powerful and should be restricted to server administrators only. It completely erases all data about all players stored by Essential Commands.

--- a/docs/Feature-Guide.md
+++ b/docs/Feature-Guide.md
@@ -121,6 +121,9 @@ Teleport to a random location in the world.
 - `rtp_cooldown` - Cooldown between random teleports (seconds) - Default: `30`
 - `rtp_max_attempts` - Maximum tries to find valid location - Default: `15`
 - `rtp_enabled_worlds` - Worlds where RTP is enabled - Default: `overworld`
+  - valid values are the registry keys of worlds that exist on your server. In vanilla, that's: `minecraft:overworld`, `minecraft:the_nether`, `minecraft:the_end`
+  - any number of entries may be provided, separated by commas, e.g. `overworld,the_nether,the_end`
+  - milelage may vary in The End, as the RTP algorithm currently struggles to quickly find safe locations in void-heavy worlds
 
 #### Bed Command
 Teleport to your bed or spawnpoint.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,6 +1,0 @@
-Welcome to the Essential-Commands wiki!
-
-Pages 
-  - [Config Documentation](https://github.com/John-Paul-R/Essential-Commands/wiki/Config-Documentation)
-  - [File Locations](https://github.com/John-Paul-R/Essential-Commands/wiki/File-locations)
-  - [List of Commands and Permissions](https://github.com/John-Paul-R/Essential-Commands/wiki/List-of-Commands-&-Permissions)

--- a/docs/Language.md
+++ b/docs/Language.md
@@ -22,4 +22,4 @@ To change the language used in Essential Commands, change the `language` setting
 
 The language files can be found in the [`src/main/resources/assets/essential_commands/lang`][lang-github] directory. To add a new one, simply copy the `en_us.json` file, naming it using the `[language-2-chars]_[region-2-chars].json` format shown above, then edit the file, replacing the English values with their equivalents in your desired language!
 
-[lang-github]: https://github.com/John-Paul-R/Essential-Commands/tree/1.21.x/src/main/resources/assets/essential_commands/lang
+[lang-github]: https://github.com/John-Paul-R/Essential-Commands/tree/26.x/src/main/resources/assets/essential_commands/lang

--- a/docs/List-of-Commands-&-Permissions.md
+++ b/docs/List-of-Commands-&-Permissions.md
@@ -20,7 +20,7 @@ Grant access to all subcommands using wildcards, like so:
 | /tpa \<player>                                 | `essentialcommands.tpa`                       | Request to teleport to a player.                                                                             |
 | /tpahere \<player>                             | `essentialcommands.tpahere`                   | Request that a player teleports to you.                                                                      |
 | /tpaccept \<player>                            | `essentialcommands.tpaccept`                  | Accept player's teleport request.                                                                            |
-| /tpdeny \<player>                              | `essentialcommands.tpdeny`                    | Deny Player's teleport request.                                                                              |
+| /tpdeny \<player>                              | `essentialcommands.tpdeny`                    | Deny player's teleport request.                                                                              |
 | /home set \<home_name>                         | `essentialcommands.home.set`                  | Set a personal home location.                                                                                |
 | /home tp \<home_name>                          | `essentialcommands.home.tp`                   | Teleport to your home.                                                                                       |
 | /home delete \<home_name>                      | `essentialcommands.home.delete`               | Delete your home.                                                                                            |
@@ -62,9 +62,9 @@ Grant access to all subcommands using wildcards, like so:
 | /day                                           | `essentialcommands.day`                       | Advance the time to the beginning of the next day, if it is nighttime.                                       |
 | /night                                         | `essentialcommands.night`                     | Advance the time to nighttime, if it is daytime.                                                             |
 | /afk                                           | `essentialcommands.afk`                       | Mark yourself as afk until you interact or use `/afk` again. Grants invuln if `invuln_while_afk` is enabled. |
-| /bed                                           | `essentialcommands.bed`                       | Teleport yourself to you vanilla bed spawn / spawnpoint.                                                     |
+| /bed                                           | `essentialcommands.bed`                       | Teleport yourself to your vanilla bed spawn / spawnpoint.                                                    |
 | /sleep                                         | `essentialcommands.sleep`                     | Start sleeping, no matter where you are!                                                                     |
-| /lastPos \<target-player>                      | `essentialcommands.admin.lasPos`              | Get the last possition of the specified (possibly offline) player.                                           |
+| /lastPos \<target-player>                      | `essentialcommands.admin.lasPos`              | Get the last position of the specified (possibly offline) player.                                            |
 | /rules                                         | `essentialcommands.rules`                     | Print the rules to the chat for self                                                                         |
 | /rules reload                                  | `essentialcommands.rules_reload`              | Reload the rules from the rules file.                                                                        |
 | /feed                                          | `essentialcommands.feed.self`                 | Fill your hunger bar & clear exhaustion.                                                                     |
@@ -72,9 +72,8 @@ Grant access to all subcommands using wildcards, like so:
 | /heal                                          | `essentialcommands.heal.self`                 | Fill your health.                                                                                            |
 | /heal \<target-player>                         | `essentialcommands.heal.others`               | Fill the target player's health.                                                                             |
 | /repair                                        | `essentialcommands.repair`                    | Repair held item.                                                                                            |
-| /suicide                                       | `essentialcommands.suicide`                   | Die.
 | /extinguish                                    | `essentialcommands.extinguish.self`           | Stop burning on self.                                                                                        |
-| /extinguish \<target-player>                   | `essentialcommands.extinguish.others`         | Stop burning on terget player.                                                                               |
+| /extinguish \<target-player>                   | `essentialcommands.extinguish.others`         | Stop burning on target player.                                                                               |
 | N/A                                            | `essentialcommands.nickname.style.color`      | Allows setting colorful nicknames.                                                                           |
 | N/A                                            | `essentialcommands.nickname.style.fancy`      | Allows setting nicknames that have special formatting (italic, bold, etc.)                                   |
 | N/A                                            | `essentialcommands.nickname.style.hover`      | Allows setting nicknames that show text on hover.                                                            |

--- a/docs/List-of-Commands-&-Permissions.md
+++ b/docs/List-of-Commands-&-Permissions.md
@@ -64,7 +64,7 @@ Grant access to all subcommands using wildcards, like so:
 | /afk                                           | `essentialcommands.afk`                       | Mark yourself as afk until you interact or use `/afk` again. Grants invuln if `invuln_while_afk` is enabled. |
 | /bed                                           | `essentialcommands.bed`                       | Teleport yourself to your vanilla bed spawn / spawnpoint.                                                    |
 | /sleep                                         | `essentialcommands.sleep`                     | Start sleeping, no matter where you are!                                                                     |
-| /lastPos \<target-player>                      | `essentialcommands.admin.lasPos`              | Get the last position of the specified (possibly offline) player.                                            |
+| /lastPos \<target-player>                      | `essentialcommands.admin.lastPos`              | Get the last position of the specified (possibly offline) player.                                           |
 | /rules                                         | `essentialcommands.rules`                     | Print the rules to the chat for self                                                                         |
 | /rules reload                                  | `essentialcommands.rules_reload`              | Reload the rules from the rules file.                                                                        |
 | /feed                                          | `essentialcommands.feed.self`                 | Fill your hunger bar & clear exhaustion.                                                                     |

--- a/docs/Player-Profiles.md
+++ b/docs/Player-Profiles.md
@@ -1,5 +1,12 @@
 # Player Profiles
 
+Profiles contain per-player settings that players can set themselves that
+affect how Essential Commands works for them, overriding the server-configured
+defaults.
+
+The following player profile settings allow tweaking how chat messages from
+Essential Commands are presented:
+
 - `/essentialcommands profile set formattingDefault <value>`
 - `/essentialcommands profile set formattingAccent <value>`
 - `/essentialcommands profile set printTeleportCoordinates <true/false>`

--- a/docs/Player-Profiles.md
+++ b/docs/Player-Profiles.md
@@ -1,5 +1,5 @@
 # Player Profiles
 
-- `/essentialcommands profile set formattingDeault <value>`
+- `/essentialcommands profile set formattingDefault <value>`
 - `/essentialcommands profile set formattingAccent <value>`
 - `/essentialcommands profile set printTeleportCoordinates <true/false>`


### PR DESCRIPTION
and fix general typos

and better describe some formats, like rtp_enabled_worlds