### PR TITLE
fix: resolve unexpected CR box characters in /rules output

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/commands/RulesCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/RulesCommand.java
@@ -48,7 +48,7 @@ public final class RulesCommand {
         if (rulesFile.createNewFile()) {
             EssentialCommands.LOGGER.info("Created rules file at path: " + rulesFile.toPath());
         }
-        String rulesStr = String.join(System.lineSeparator(), Files.readAllLines(rulesFile.toPath()));
+        String rulesStr = String.join("\n", Files.readAllLines(rulesFile.toPath()));
         rulesText = TextUtil.parseText(rulesStr);
     }
 }


### PR DESCRIPTION
### Description

Fixes #181

This PR properly fixes the unexpected CR (carriage return) box characters displayed in the `/rules` command output, which was previously addressed in #181 but not fully resolved for all environments.

### Cause of the Issue
The previous implementation used `System.lineSeparator()`. When the server runs on **Windows**, this method returns `\r\n` (CRLF). 
However, the Minecraft client text renderer does not filter out or properly interpret the `\r` (CR) character, causing it to render as a broken box/control character in-game. 

### Solution
Changed `System.lineSeparator()` to a hardcoded `\n` (LF) when joining the lines. This ensures consistent text formatting across all server hosting OS environments (Linux/Windows) and perfectly compatible with the Minecraft client.

### Testing
Tested on Windows environment: Verified that this fix successfully removes the CR box characters and the `/rules` text renders correctly in-game.