### PR TITLE
Fix: use at least permission level 2 when checking permissions using permissions API

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/ECPerms.java
+++ b/src/main/java/com/fibermc/essentialcommands/ECPerms.java
@@ -138,7 +138,7 @@ public final class ECPerms {
                 if (defaultRequireLevel > 4) {
                     return source.checkPermission(permission, false);
                 }
-                return source.checkPermission(permission, PermissionLevel.byId(defaultRequireLevel));
+                return source.checkPermission(permission, PermissionLevel.byId(Math.max(2, defaultRequireLevel)));
             } catch (Exception e) {
                 EssentialCommands.LOGGER.error(e);
                 return false;


### PR DESCRIPTION
This PR makes a small fix to an oversight I made in my 26.2 update PR (#391). I had accidentally removed the line of code that results in checking at least permission level 2 when checking permissions using the permissions API (see [this](https://github.com/John-Paul-R/Essential-Commands/blob/399e0504d3ff73c944ab8fcdde0d9d332a1f0f31/src/main/java/com/fibermc/essentialcommands/ECPerms.java#L136) line of code before the 26.2 update). This PR re-introduces that behaviour.