### PR TITLE
Fix EssentialsX home conversion for active and new players

### DIFF
--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataFactory.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataFactory.java
@@ -65,6 +65,15 @@ public final class PlayerDataFactory {
     public static PlayerData create(NamedLocationStorage homes, File saveFile) {
         String fileName = saveFile.getName();
         UUID playerUuid = UUID.fromString(fileName.substring(0, fileName.indexOf(".dat")));
+
+        if (PlayerDataManager.exists()) {
+            PlayerData activePlayerData = PlayerDataManager.getInstance().getByUuid(playerUuid);
+            if (activePlayerData != null) {
+                activePlayerData.homes.putAll(homes);
+                activePlayerData.setDirty();
+                return activePlayerData;
+            }
+        }
         PlayerData playerData = null;
         if (Files.exists(saveFile.toPath()) && saveFile.length() != 0) {
             try {
@@ -98,6 +107,7 @@ public final class PlayerDataFactory {
 
         if (playerData == null) {
             playerData = new PlayerData(saveFile);
+            playerData.homes.putAll(homes);
         }
 
         playerData.setDirty();


### PR DESCRIPTION
## Summary

Fixes EssentialsX home conversion in two cases:

Written with GPT 5.6 so use with caution.

1. When a player is currently online, imported homes are merged into the active `PlayerData` instance. This prevents the converted homes from being overwritten when the player's active data is later saved.

2. When no existing Essential Commands player data exists, the newly created `PlayerData` is populated with the imported homes.

This addresses the conversion behavior described in #357.

## Testing

Tested on Fabric 26.2 / Essential Commands 0.41.0.

The fix was previously tested in the patched JAR, including persistence of converted homes and conversion for players without existing Essential Commands player data.

The project builds successfully with Gradle.

Fixes #357