### PR TITLE
docs: document nickname text styling #287

### DIFF
--- a/docs/Feature-Guide.md
+++ b/docs/Feature-Guide.md
@@ -199,26 +199,18 @@ Customize player display names.
 | Clear other's nickname | `/nickname clear <player>` | `essentialcommands.nickname.others` |
 | Find player by nickname | `/nickname reveal <nickname>` | `essentialcommands.nickname.reveal` |
 
-**Styling**
+The `<nickname>` is [MinecraftText](./Minecraft-Text.md), meaning it can be one of:
 
-`/nickname set` takes the same JSON (or quoted string) as `/tellraw`. A plain name needs no extra permissions. Color, bold/italic, hover text, and click actions each need their own node — without it the command fails.
-
-```
-/nickname set "Alex"
-/nickname set {"text":"Alex","color":"gold"}
-/nickname set {"text":"Alex","bold":true,"italic":true}
-/nickname set {"text":"Alex","hoverEvent":{"action":"show_text","contents":"Hello"}}
-/nickname set {"text":"Alex","clickEvent":{"action":"suggest_command","value":"/msg Alex "}}
-```
-
-You can build the JSON in a tellraw generator such as [MinecraftJson](https://www.minecraftjson.com/).
+1. A plain name with no spaces like `Alex`
+2. A [Minecraft Text JSON object](./Minecraft-Text) like `{"text":"Alex","color":"green"}`
+3. A [Text Placeholder API styled string](https://placeholders.pb4.eu/user/text-format/) like `<green>Alex</green>`
 
 **Additional Permissions:**
 - `essentialcommands.nickname.style.color` - Use colored nicknames
 - `essentialcommands.nickname.style.fancy` - Use formatted nicknames (bold, italic, underline, strikethrough, obfuscated, or a non-default font)
 - `essentialcommands.nickname.style.hover` - Use hover effects on nicknames
 - `essentialcommands.nickname.style.click` - Use click actions on nicknames
-- `essentialcommands.nickname.placeholders` - Parse Placeholder API tags in the nickname
+- `essentialcommands.nickname.placeholders` - Parse [Placeholder API tags](https://placeholders.pb4.eu/user/default-placeholders/) in the nickname
 - `essentialcommands.nickname.style.selector_and_context` - Resolve selectors (for example `@s`) against the target player
 
 **Related Config Options:**

--- a/docs/Feature-Guide.md
+++ b/docs/Feature-Guide.md
@@ -199,11 +199,27 @@ Customize player display names.
 | Clear other's nickname | `/nickname clear <player>` | `essentialcommands.nickname.others` |
 | Find player by nickname | `/nickname reveal <nickname>` | `essentialcommands.nickname.reveal` |
 
+**Styling**
+
+`/nickname set` takes the same JSON (or quoted string) as `/tellraw`. A plain name needs no extra permissions. Color, bold/italic, hover text, and click actions each need their own node — without it the command fails.
+
+```
+/nickname set "Alex"
+/nickname set {"text":"Alex","color":"gold"}
+/nickname set {"text":"Alex","bold":true,"italic":true}
+/nickname set {"text":"Alex","hoverEvent":{"action":"show_text","contents":"Hello"}}
+/nickname set {"text":"Alex","clickEvent":{"action":"suggest_command","value":"/msg Alex "}}
+```
+
+You can build the JSON in a tellraw generator such as [MinecraftJson](https://www.minecraftjson.com/).
+
 **Additional Permissions:**
 - `essentialcommands.nickname.style.color` - Use colored nicknames
-- `essentialcommands.nickname.style.fancy` - Use formatted nicknames (bold, italic)
+- `essentialcommands.nickname.style.fancy` - Use formatted nicknames (bold, italic, underline, strikethrough, obfuscated, or a non-default font)
 - `essentialcommands.nickname.style.hover` - Use hover effects on nicknames
 - `essentialcommands.nickname.style.click` - Use click actions on nicknames
+- `essentialcommands.nickname.placeholders` - Parse Placeholder API tags in the nickname
+- `essentialcommands.nickname.style.selector_and_context` - Resolve selectors (for example `@s`) against the target player
 
 **Related Config Options:**
 - `enable_nick` - Enables/disables nickname functionality - Default: `true`

--- a/docs/List-of-Commands-&-Permissions.md
+++ b/docs/List-of-Commands-&-Permissions.md
@@ -78,6 +78,8 @@ Grant access to all subcommands using wildcards, like so:
 | N/A                                            | `essentialcommands.nickname.style.fancy`      | Allows setting nicknames that have special formatting (italic, bold, etc.)                                   |
 | N/A                                            | `essentialcommands.nickname.style.hover`      | Allows setting nicknames that show text on hover.                                                            |
 | N/A                                            | `essentialcommands.nickname.style.click`      | Allows setting nicknames that execute an action on click.                                                    |
+| N/A                                            | `essentialcommands.nickname.placeholders`     | Parse Placeholder API tags in `/nickname set`.                                                               |
+| N/A                                            | `essentialcommands.nickname.style.selector_and_context` | Resolve selectors in nickname text against the target player.                                       |
 | /essentialcommands config reload               | `essentialcommands.config.reload`             | Reload essentialcommands config.                                                                             |
 
 ## Rules/Config Bypass Permissions
@@ -99,4 +101,12 @@ Essentially, any value that works for `/tellraw`'s message field. (JSON text or 
 
 You can use a tellraw generator like [MinecraftJson](https://www.minecraftjson.com/) to create this JSON text with a graphical interface and preview.
 
-Examples: `"Alexandra"`, `{"text":"Alex","color":"green","bold":true}`
+Examples:
+
+- `"Alexandra"` — plain name, no extra permissions
+- `{"text":"Alex","color":"green"}` — needs `essentialcommands.nickname.style.color`
+- `{"text":"Alex","bold":true}` — needs `essentialcommands.nickname.style.fancy`
+- `{"text":"Alex","hoverEvent":{"action":"show_text","contents":"Hello"}}` — needs `essentialcommands.nickname.style.hover`
+- `{"text":"Alex","clickEvent":{"action":"suggest_command","value":"/msg Alex "}}` — needs `essentialcommands.nickname.style.click`
+
+See [Feature Guide — Nicknames](Feature-Guide.md#nicknames) for the `/nickname set` examples.

--- a/docs/List-of-Commands-&-Permissions.md
+++ b/docs/List-of-Commands-&-Permissions.md
@@ -37,8 +37,8 @@ Grant access to all subcommands using wildcards, like so:
 | /back                                          | `essentialcommands.back`                      | Teleport to your previous location.                                                                          |
 | /spawn tp \|\| /spawn                          | `essentialcommands.spawn.tp`                  | Teleport to the server spawn.                                                                                |
 | /spawn set                                     | `essentialcommands.spawn.set`                 | Set the server spawn.                                                                                        |
-| /nickname set \<nickname>                      | `essentialcommands.nickname.self`             | Set your own nickname to specified MinecraftText.                                                            |
-| /nickname set \<target-player> \<nickname>     | `essentialcommands.nickname.others`           | Set target player's nickname to specified MinecraftText.                                                     |
+| /nickname set \<nickname>                      | `essentialcommands.nickname.self`             | Set your own nickname to specified [MinecraftText](./Minecraft-Text.md).                                     |
+| /nickname set \<target-player> \<nickname>     | `essentialcommands.nickname.others`           | Set target player's nickname to specified [MinecraftText](./Minecraft-Text.md).                              |
 | /nickname clear                                | `essentialcommands.nickname.self`             | Clear your own nickname.                                                                                     |
 | /nickname clear \<target-player>               | `essentialcommands.nickname.others`           | Clear target player's nickname.                                                                              |
 | /nickname reveal \<player-nickname>            | `essentialcommands.nickname.reveal`           | Get list of players with the provided nickname (String, case-insensitive).                                   |
@@ -79,7 +79,7 @@ Grant access to all subcommands using wildcards, like so:
 | N/A                                            | `essentialcommands.nickname.style.hover`      | Allows setting nicknames that show text on hover.                                                            |
 | N/A                                            | `essentialcommands.nickname.style.click`      | Allows setting nicknames that execute an action on click.                                                    |
 | N/A                                            | `essentialcommands.nickname.placeholders`     | Parse Placeholder API tags in `/nickname set`.                                                               |
-| N/A                                            | `essentialcommands.nickname.style.selector_and_context` | Resolve selectors in nickname text against the target player.                                       |
+| N/A                                            | `essentialcommands.nickname.style.selector_and_context` | Resolve selectors in nickname text.                                                                |
 | /essentialcommands config reload               | `essentialcommands.config.reload`             | Reload essentialcommands config.                                                                             |
 
 ## Rules/Config Bypass Permissions
@@ -92,21 +92,3 @@ Permission | Description
 `essentialcommands.bypass.allow_teleport_between_dimensions` | Ignore `allow_teleport_between_dimensions`.
 `essentialcommands.bypass.teleport_interrupt_on_damaged` | Ignore `teleport_interrupt_on_damaged`.
 `essentialcommands.bypass.teleport_interrupt_on_move` | Ignore `teleport_interrupt_on_move`.
-
-## Types
-
-### MinecraftText
-
-Essentially, any value that works for `/tellraw`'s message field. (JSON text or string enclosed by quotes)
-
-You can use a tellraw generator like [MinecraftJson](https://www.minecraftjson.com/) to create this JSON text with a graphical interface and preview.
-
-Examples:
-
-- `"Alexandra"` — plain name, no extra permissions
-- `{"text":"Alex","color":"green"}` — needs `essentialcommands.nickname.style.color`
-- `{"text":"Alex","bold":true}` — needs `essentialcommands.nickname.style.fancy`
-- `{"text":"Alex","hoverEvent":{"action":"show_text","contents":"Hello"}}` — needs `essentialcommands.nickname.style.hover`
-- `{"text":"Alex","clickEvent":{"action":"suggest_command","value":"/msg Alex "}}` — needs `essentialcommands.nickname.style.click`
-
-See [Feature Guide — Nicknames](Feature-Guide.md#nicknames) for the `/nickname set` examples.

--- a/docs/Minecraft-Text.md
+++ b/docs/Minecraft-Text.md
@@ -1,0 +1,11 @@
+# MinecraftText
+
+Text can usually be specified in a few formats:
+
+1. Plainly, like `"Alex"`
+2. Minecraft's JSON format, used in `/tellraw` text, like `{"text":"Alex","color":"green","bold":true}`
+3. [Text Placeholder API's QuickText format][quick-text], like `<green><bold>Alex</bold></green>`
+
+You can use a tellraw generator like [MinecraftJson](https://www.minecraftjson.com/) to create this JSON text with a graphical interface and preview.
+
+[quick-text]: https://placeholders.pb4.eu/user/quicktext/


### PR DESCRIPTION
`/nickname set` takes the same JSON as `/tellraw`, but the style permissions were never shown next to examples.

I added `/nickname set` examples for color, bold/italic, hover, and click in the Feature Guide, and listed which permission each needs. Placeholder API tags and selector resolution are in the permissions table too.

Closes #287