### PR TITLE
docs: clarify nickname style perms apply to the target #44

### DIFF
--- a/docs/Feature-Guide.md
+++ b/docs/Feature-Guide.md
@@ -206,12 +206,15 @@ The `<nickname>` is [MinecraftText](./Minecraft-Text.md), meaning it can be one 
 3. A [Text Placeholder API styled string](https://placeholders.pb4.eu/user/text-format/) like `<green>Alex</green>`
 
 **Additional Permissions:**
-- `essentialcommands.nickname.style.color` - Use colored nicknames
-- `essentialcommands.nickname.style.fancy` - Use formatted nicknames (bold, italic, underline, strikethrough, obfuscated, or a non-default font)
-- `essentialcommands.nickname.style.hover` - Use hover effects on nicknames
-- `essentialcommands.nickname.style.click` - Use click actions on nicknames
-- `essentialcommands.nickname.placeholders` - Parse [Placeholder API tags](https://placeholders.pb4.eu/user/default-placeholders/) in the nickname
-- `essentialcommands.nickname.style.selector_and_context` - Resolve selectors (for example `@s`) against the target player
+
+Style permissions are checked on the player who wears the nickname, not on whoever runs `/nickname set`. They do not grant the set or clear commands.
+
+- `essentialcommands.nickname.style.color` - Color may be applied to this player's nickname
+- `essentialcommands.nickname.style.fancy` - Bold, italic, underline, strikethrough, obfuscated, or a non-default font may be applied to this player's nickname
+- `essentialcommands.nickname.style.hover` - Hover text may be applied to this player's nickname
+- `essentialcommands.nickname.style.click` - Click actions may be applied to this player's nickname
+- `essentialcommands.nickname.placeholders` - The command sender may parse [Placeholder API tags](https://placeholders.pb4.eu/user/default-placeholders/) in the nickname
+- `essentialcommands.nickname.style.selector_and_context` - The command sender may resolve selectors (for example `@s`) against the target player
 
 **Related Config Options:**
 - `enable_nick` - Enables/disables nickname functionality - Default: `true`

--- a/docs/List-of-Commands-&-Permissions.md
+++ b/docs/List-of-Commands-&-Permissions.md
@@ -74,12 +74,12 @@ Grant access to all subcommands using wildcards, like so:
 | /repair                                        | `essentialcommands.repair`                    | Repair held item.                                                                                            |
 | /extinguish                                    | `essentialcommands.extinguish.self`           | Stop burning on self.                                                                                        |
 | /extinguish \<target-player>                   | `essentialcommands.extinguish.others`         | Stop burning on target player.                                                                               |
-| N/A                                            | `essentialcommands.nickname.style.color`      | Allows setting colorful nicknames.                                                                           |
-| N/A                                            | `essentialcommands.nickname.style.fancy`      | Allows setting nicknames that have special formatting (italic, bold, etc.)                                   |
-| N/A                                            | `essentialcommands.nickname.style.hover`      | Allows setting nicknames that show text on hover.                                                            |
-| N/A                                            | `essentialcommands.nickname.style.click`      | Allows setting nicknames that execute an action on click.                                                    |
-| N/A                                            | `essentialcommands.nickname.placeholders`     | Parse Placeholder API tags in `/nickname set`.                                                               |
-| N/A                                            | `essentialcommands.nickname.style.selector_and_context` | Resolve selectors in nickname text.                                                                |
+| N/A                                            | `essentialcommands.nickname.style.color`      | Allow color on this player's nickname. Does not grant `/nickname set`.                                       |
+| N/A                                            | `essentialcommands.nickname.style.fancy`      | Allow bold/italic/etc. on this player's nickname. Does not grant `/nickname set`.                            |
+| N/A                                            | `essentialcommands.nickname.style.hover`      | Allow hover text on this player's nickname. Does not grant `/nickname set`.                                  |
+| N/A                                            | `essentialcommands.nickname.style.click`      | Allow click actions on this player's nickname. Does not grant `/nickname set`.                               |
+| N/A                                            | `essentialcommands.nickname.placeholders`     | Command sender may parse Placeholder API tags in `/nickname set`.                                            |
+| N/A                                            | `essentialcommands.nickname.style.selector_and_context` | Command sender may resolve selectors in nickname text.                                             |
 | /essentialcommands config reload               | `essentialcommands.config.reload`             | Reload essentialcommands config.                                                                             |
 
 ## Rules/Config Bypass Permissions


### PR DESCRIPTION
Style permissions are checked on the player who wears the nickname, not on whoever runs `/nickname set`.

I rewrote those descriptions so they don't read like they grant the set command. Placeholders and selector resolution stay on the command sender.

Closes #44