### PR TITLE
update to 26.3-rc2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx2048M
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.2
-loader_version=0.18.3
+minecraft_version=26.3-rc-2
+loader_version=0.19.5
 loom_version=1.17-SNAPSHOT
 
 # Fabric API
-fabric_api_version=0.152.1+26.2
+fabric_api_version=0.160.4+26.3
 
 # Mod Properties
 mod_name = Essential Commands
@@ -19,15 +19,15 @@ maven_group = com.fibermc
 archives_base_name = essential_commands
 
 # Common Publishing
-game_versions=26.2
+game_versions=26.3
 gh_owner=John-Paul-R
 gh_repo=essential-commands
 
 # Dependencies
 # check this on https://github.com/Patbox/TextPlaceholderAPI/releases
-placeholder_api_version=3.1.0-beta.1+26.2
+placeholder_api_version=3.2.0+26.3
 # check this on https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
-server_translations_api_version=3.1.0+26.2
+server_translations_api_version=3.2.0+26.3
 # check this on https://github.com/Ladysnake/PlayerAbilityLib/releases
 pal_version=1.16.0
 # check this on https://github.com/DrexHD/Vanish/releases

--- a/src/main/java/com/fibermc/essentialcommands/commands/suggestions/OfflinePlayerRepo.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/suggestions/OfflinePlayerRepo.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.yggdrasil.response.NameAndId;
+import com.mojang.authlib.services.response.NameAndId;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ClientInformation;

--- a/src/main/java/com/fibermc/essentialcommands/mixin/ClientboundPlayerInfoUpdatePacketActionMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/ClientboundPlayerInfoUpdatePacketActionMixin.java
@@ -23,7 +23,7 @@ public class ClientboundPlayerInfoUpdatePacketActionMixin {
     ClientboundPlayerInfoUpdatePacket.Action.Writer writer;
 
     @Inject(method = "<init>", at = @At(value = "RETURN"))
-    public void ctor(String string, int i, ClientboundPlayerInfoUpdatePacket.Action.Reader reader, ClientboundPlayerInfoUpdatePacket.Action.Writer argWriter, CallbackInfo ci) {
+    public void ctor(String string, int id, int idAgain, ClientboundPlayerInfoUpdatePacket.Action.Reader reader, ClientboundPlayerInfoUpdatePacket.Action.Writer argWriter, CallbackInfo ci) {
         if (!"ADD_PLAYER".equals(string)) {
             return;
         }
@@ -32,8 +32,8 @@ public class ClientboundPlayerInfoUpdatePacketActionMixin {
         writer = (buf, entry) -> {
             // Need to use the backing config, since this lambda captures the field value.
             if (BACKING_CONFIG.NICKNAME_ABOVE_HEAD.getValue()) {
-                var id = entry.profileId();
-                var playerData = PlayerDataManager.getInstance().getByUuid(id);
+                var profileId = entry.profileId();
+                var playerData = PlayerDataManager.getInstance().getByUuid(profileId);
                 if (playerData == null) {
                     // playerData may return null in some cases.
                     // One known case is when a Taterzen from the Taterzens mod

--- a/src/main/java/com/fibermc/essentialcommands/teleportation/PlayerTeleporter.java
+++ b/src/main/java/com/fibermc/essentialcommands/teleportation/PlayerTeleporter.java
@@ -9,18 +9,18 @@ import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
 import com.fibermc.essentialcommands.playerdata.PlayerData;
 import com.fibermc.essentialcommands.types.MinecraftLocation;
 
-import net.minecraft.resources.Identifier;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.permissions.Permission;
 import net.minecraft.server.permissions.PermissionLevel;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySpawnReason;
@@ -152,7 +152,7 @@ public final class PlayerTeleporter {
                 }
             } else {
                 targetWorld.getChunk((int) targetVec.x >> 4, (int) targetVec.z >> 4);
-                pet.randomTeleport(targetVec.x, targetVec.y + 0.5, targetVec.z, false);
+                pet.randomTeleport(targetVec.x, targetVec.y + 0.5, targetVec.z, false, BlockTags.CAT_DOES_NOT_TELEPORT_TO);
             }
         }
     }


### PR DESCRIPTION
runs and joins just fine, we'll have to see if PAL updates, but /fly works

ClientboundPlayerInfoUpdatePacketActionMixin string check is verified to be the same variable and value 
PlayerTeleporter pet mover is stolen from the only pet usage I could find (Cat), others were Enderman and Chorus Fruit